### PR TITLE
add .travis.yml config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,75 @@
+#
+# Use ubuntu trusty (14.04) with sudo privileges.
+dist: trusty
+sudo: required
+language:
+  - generic
+cache:
+  - apt
+
+# Configuration variables. All variables are global now, but this can be used to
+# trigger a build matrix for different ROS distributions if desired.
+env:
+  global:
+    - ROS_DISTRO=indigo
+    - ROS_CI_DESKTOP="`lsb_release -cs`"  # e.g. [precise|trusty|...]
+    - CI_SOURCE_PATH=$(pwd)
+    - ROSINSTALL_FILE=$CI_SOURCE_PATH/dependencies.rosinstall
+    - CATKIN_OPTIONS=$CI_SOURCE_PATH/catkin.options
+    - ROS_PARALLEL_JOBS='-j1 -l6'
+
+################################################################################
+
+# Install system dependencies, namely a very barebones ROS setup.
+before_install:
+  - sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+  - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+  - sudo apt-get update -qq
+  - sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-$ROS_DISTRO-catkin 
+  - source /opt/ros/$ROS_DISTRO/setup.bash
+  # Prepare rosdep to install dependencies.
+  - sudo rosdep init
+  - rosdep update -qq
+  - sudo apt-get install -y build-essential pkg-config cmake 
+  - sudo apt-get install -y libvtk5-dev python-vtk libvtk-java
+  - sudo apt-get install -y libwxgtk2.8-dev libftdi-dev freeglut3-dev
+  - sudo apt-get install -y zlib1g-dev libusb-1.0-0-dev libudev-dev libfreenect-dev
+  - sudo apt-get install -y libdc1394-22-dev libavformat-dev libswscale-dev
+  - sudo apt-get install -y libassimp-dev libjpeg-dev libopencv-dev libgtest-dev
+  - sudo apt-get install -y libeigen3-dev libsuitesparse-dev libpcap-dev
+  - sudo apt-get -y install libmrpt-dev
+
+# Create a catkin workspace with the package under integration.
+install:
+  - mkdir -p ~/catkin_ws/src
+  - cd ~/catkin_ws/src
+  - catkin_init_workspace
+  # Create the devel/setup.bash (run catkin_make with an empty workspace) and
+  # source it to set the path variables.
+  - cd ~/catkin_ws
+  - catkin_make
+  - source devel/setup.bash
+  # Add the package under integration to the workspace using a symlink.
+  - cd ~/catkin_ws/src
+  - ln -s $CI_SOURCE_PATH .
+
+# Install all dependencies, using wstool and rosdep.
+# wstool looks for a ROSINSTALL_FILE defined in the environment variables.
+before_script:
+  # source dependencies: install using wstool.
+  - cd ~/catkin_ws/src
+  - wstool init
+  - if [[ -f $ROSINSTALL_FILE ]] ; then wstool merge $ROSINSTALL_FILE ; fi
+  - wstool up
+  # package depdencies: install using rosdep.
+  - cd ~/catkin_ws
+  - rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+
+# Compile and test. If the CATKIN_OPTIONS file exists, use it as an argument to
+# catkin_make.
+script:
+  - cd ~/catkin_ws
+  - catkin_make $( [ -f $CATKIN_OPTIONS ] && cat $CATKIN_OPTIONS )
+  # Testing: Use both run_tests (to see the output) and test (to error out).
+  - catkin_make run_tests  # This always returns 0, but looks pretty.
+  - catkin_make test  # This will return non-zero if a test fails.


### PR DESCRIPTION
I tested this config, it worked for the commit before adding new messages: https://github.com/mrpt-ros-pkg/mrpt_navigation/commit/c10c8c24e220674a30e60bb25548fab45db1576e

You can see it here: https://travis-ci.org/Logrus/mrpt_navigation/builds/117089968

It should also work in general, but it seems that the latest builds fail.
I am also having trouble with ```catkin_make``` at the moment. It complains about missing ```mrpt_msgs/ObservationRangeBeacon.h```.