### PR TITLE
Add method to publish pose in ROS data type

### DIFF
--- a/mrpt_localization/include/mrpt_localization_node.h
+++ b/mrpt_localization/include/mrpt_localization_node.h
@@ -94,7 +94,7 @@ public:
     void callbackInitialpose (const geometry_msgs::PoseWithCovarianceStamped&);
     void updateMap (const nav_msgs::OccupancyGrid&);
     void publishTF();
-    void publishPose() ;
+    void publishPose(const sensor_msgs::LaserScan&) ;
 
 private: //functions
     Parameters *param();

--- a/mrpt_localization/include/mrpt_localization_node.h
+++ b/mrpt_localization/include/mrpt_localization_node.h
@@ -44,6 +44,11 @@
 #include "mrpt_msgs/ObservationRangeBeacon.h"
 #include <std_msgs/Header.h>
 
+#include <mrpt/math.h>
+#include <mrpt_bridge/pose.h>
+
+#include <cstring>  // size_t
+
 #include <mrpt/version.h>
 #if MRPT_VERSION>=0x130
 #	include <mrpt/obs/CObservationOdometry.h>
@@ -89,6 +94,8 @@ public:
     void callbackInitialpose (const geometry_msgs::PoseWithCovarianceStamped&);
     void updateMap (const nav_msgs::OccupancyGrid&);
     void publishTF();
+    void publishPose() ;
+
 private: //functions
     Parameters *param();
     void update ();
@@ -100,6 +107,7 @@ private: //functions
     ros::Publisher pub_Particles_;
     ros::Publisher pub_map_;
     ros::Publisher pub_metadata_;
+    ros::Publisher pub_pose_ ;
     ros::ServiceServer service_map_;
     tf::TransformListener listenerTF_;
     tf::TransformBroadcaster tf_broadcaster_;
@@ -114,6 +122,7 @@ private: //functions
     void publishMap ();
     virtual bool waitForMap();
     nav_msgs::GetMap::Response resp_;
+    
 };
 
 #endif // MRPT_LOCALIZATION_NODE_H

--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -341,6 +341,7 @@ void PFLocalizationNode::publishTF() {
 /**
  * publishPose()
  * @beief publish the current pose of the robot
+ * @param msg  Laser Scan Message
  **/ 
 void PFLocalizationNode::publishPose(const sensor_msgs::LaserScan &_msg) {
   mrpt::math::CMatrixDouble33 cov ;  // cov for x, y, phi (meter, meter, radian)

--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -342,7 +342,7 @@ void PFLocalizationNode::publishTF() {
  * publishPose()
  * @beief publish the current pose of the robot
  **/ 
-void PFLocalizationNode::publishPose() {
+void PFLocalizationNode::publishPose(const sensor_msgs::LaserScan &_msg) {
   mrpt::math::CMatrixDouble33 cov ;  // cov for x, y, phi (meter, meter, radian)
   mrpt::poses::CPose2D mean ;
   
@@ -353,7 +353,7 @@ void PFLocalizationNode::publishPose() {
   std::string global_frame_id = tf::resolve(param()->tf_prefix, param()->global_frame_id);
   
   p.header.frame_id = global_frame_id ;
-  p.header.stamp = LaserScan->header.stamp ;
+  p.header.stamp = _msg.header.stamp ;
   
   // copy in the pose
   p.pose.pose.position.x = mean.x() ;

--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -35,6 +35,7 @@
 #include <mrpt_bridge/time.h>
 #include <mrpt_bridge/map.h>
 #include <mrpt_bridge/beacon.h>
+
 #include <std_msgs/Header.h>
 
 #include <mrpt/version.h>
@@ -95,6 +96,8 @@ void PFLocalizationNode::init() {
         service_map_ = n_.advertiseService("static_map", &PFLocalizationNode::mapCallback, this);
     }
     pub_Particles_ = n_.advertise<geometry_msgs::PoseArray>("particlecloud", 1, true);
+    
+    pub_pose_ = n_.advertise<geometry_msgs::PoseWithCovarianceStamped>("mrpt_pose", 2, true) ;
 }
 
 void PFLocalizationNode::loop() {
@@ -308,6 +311,7 @@ void PFLocalizationNode::publishTF() {
     ros::Time stamp;
     mrpt_bridge::convert(timeLastUpdate_, stamp);
     mrpt_bridge::convert(robotPose, tmp_tf);
+    
     try
     {
         tf::Stamped<tf::Pose> tmp_tf_stamped (tmp_tf.inverse(), stamp,  base_frame_id);
@@ -332,4 +336,65 @@ void PFLocalizationNode::publishTF() {
                                         global_frame_id, odom_frame_id);
     tf_broadcaster_.sendTransform(tmp_tf_stamped);
     //ROS_INFO("%s, %s\n", global_frame_id.c_str(), odom_frame.c_str());
+}
+
+/**
+ * publishPose()
+ * @beief publish the current pose of the robot
+ **/ 
+void PFLocalizationNode::publishPose() {
+  mrpt::math::CMatrixDouble33 cov ;  // cov for x, y, phi (meter, meter, radian)
+  mrpt::poses::CPose2D mean ;
+  
+  pdf_.getCovarianceAndMean(cov, mean) ;
+  
+  geometry_msgs::PoseWithCovarianceStamped p ;
+  // Fill in the header
+  std::string global_frame_id = tf::resolve(param()->tf_prefix, param()->global_frame_id);
+  
+  p.header.frame_id = global_frame_id ;
+  p.header.stamp = LaserScan->header.stamp ;
+  
+  // copy in the pose
+  p.pose.pose.position.x = mean.x() ;
+  p.pose.pose.position.y = mean.y() ;
+//  p.pose.pose.orientation = mean.phi() ;
+  
+  const double yaw = mean.phi() ;
+  
+  if (std::abs(yaw) < 1e-10) {
+    p.pose.pose.position.x = 0 ;
+    p.pose.pose.position.y = 0 ;
+    p.pose.pose.orientation.w = 1. ;
+  }
+  else {
+    const double s = ::sin(yaw * .5) ;
+    const double c = ::cos(yaw * .5) ;
+    p.pose.pose.position.x = 0. ;
+    p.pose.pose.position.y = 0. ;
+    p.pose.pose.orientation.w = c ;
+  }
+  
+  // Copy in the covariance, converting from 3-D to 6-D
+  for (int i = 0 ; i < 2 ; i++) {
+    for (int j = 0 ; j < 2 ; j++) {
+      double cov_val ;
+      int ros_i = i ;
+      int ros_j = j ;
+      if (i > 2 || j > 2) {
+	cov_val = 0 ;
+      }
+      else {
+	ros_i = i == 2 ? 5 : i ;
+	ros_j = j == 2 ? 5 : j ;
+	cov_val = cov(i, j) ;
+      }
+      
+      p.pose.covariance[ros_i * 6 + ros_j] = cov_val;
+    }
+  }
+   
+  
+  pub_pose_.publish(p) ;
+  
 }


### PR DESCRIPTION
Added the method publishPose () to convert MRPT data type pose to ROS topic of type geometry_msgs/PoseWithCovarianceStamped. The published topic is called /mrpt_pose. 

