### PR TITLE
Backward compatibility fix to PR #30

### DIFF
--- a/mrpt_bridge/CMakeLists.txt
+++ b/mrpt_bridge/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(catkin REQUIRED COMPONENTS
 	roscpp std_msgs tf 
 	message_generation geometry_msgs sensor_msgs mrpt_msgs nav_msgs)
 
+find_package(MRPT REQUIRED base obs maps slam)
+include_directories(${MRPT_INCLUDE_DIRS})
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 #find_package( OpenCV REQUIRED )
@@ -18,7 +20,7 @@ include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
-find_package(MRPT REQUIRED base obs maps slam)
+#find_package(MRPT REQUIRED base obs maps slam)
 #include_directories(${MRPT_INCLUDE_DIRS})
 #MESSAGE( STATUS "MRPT_INCLUDE_DIRS: " ${MRPT_INCLUDE_DIRS})
 #link_directories(${MRPT_LIBRARY_DIRS})

--- a/mrpt_bridge/CMakeLists.txt
+++ b/mrpt_bridge/CMakeLists.txt
@@ -8,8 +8,6 @@ find_package(catkin REQUIRED COMPONENTS
 	roscpp std_msgs tf 
 	message_generation geometry_msgs sensor_msgs mrpt_msgs nav_msgs)
 
-find_package(MRPT REQUIRED base obs maps slam)
-include_directories(${MRPT_INCLUDE_DIRS})
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 #find_package( OpenCV REQUIRED )
@@ -20,7 +18,7 @@ include_directories(${PCL_INCLUDE_DIRS})
 link_directories(${PCL_LIBRARY_DIRS})
 add_definitions(${PCL_DEFINITIONS})
 
-#find_package(MRPT REQUIRED base obs maps slam)
+find_package(MRPT REQUIRED base obs maps slam)
 #include_directories(${MRPT_INCLUDE_DIRS})
 #MESSAGE( STATUS "MRPT_INCLUDE_DIRS: " ${MRPT_INCLUDE_DIRS})
 #link_directories(${MRPT_LIBRARY_DIRS})

--- a/mrpt_localization/include/mrpt_localization/mrpt_localization_core.h
+++ b/mrpt_localization/include/mrpt_localization/mrpt_localization_core.h
@@ -37,7 +37,6 @@
 #include <mrpt/poses/CPosePDFGaussian.h>
 #include <mrpt/utils/CTicTac.h>
 #include <mrpt/utils/CTicTac.h>
-#include <mrpt/poses/CPose2D.h>
 #include <mrpt/slam/CMonteCarloLocalization2D.h>
 #include <mrpt_bridge/mrpt_log_macros.h>
 

--- a/mrpt_localization/include/mrpt_localization_node.h
+++ b/mrpt_localization/include/mrpt_localization_node.h
@@ -119,7 +119,7 @@ private: //functions
     ros::NodeHandle n_;
     unsigned long loop_count_;
     void publishParticles();
-    void setLogLevel();
+    void useROSLogLevel();
 
     bool waitForTransform(mrpt::poses::CPose3D &des, const std::string& target_frame, const std::string& source_frame, const ros::Time& time, const ros::Duration& timeout, const ros::Duration& polling_sleep_duration = ros::Duration(0.01));
     bool mapCallback(nav_msgs::GetMap::Request  &req, nav_msgs::GetMap::Response &res );

--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -70,6 +70,9 @@ PFLocalizationNode::Parameters *PFLocalizationNode::param() {
 }
 
 void PFLocalizationNode::init() {
+    // Use MRPT library the same log level as on ROS nodes (only for MRPT_VERSION >= 0x130)
+    useROSLogLevel();
+
     PFLocalization::init();
     subInitPose_ = n_.subscribe("initialpose", 1, &PFLocalizationNode::callbackInitialpose, this);
 
@@ -376,7 +379,8 @@ void PFLocalizationNode::publishPose() {
   pub_pose_.publish(p) ;
 }
 
-void PFLocalizationNode::setLogLevel() {
+void PFLocalizationNode::useROSLogLevel() {
+#if MRPT_VERSION>=0x130
   // Set ROS log level also on MRPT internal log system; level enums are fully compatible
   std::map<std::string, ros::console::levels::Level> loggers;
   ros::console::get_loggers(loggers);
@@ -384,4 +388,5 @@ void PFLocalizationNode::setLogLevel() {
     pdf_.setVerbosityLevel(static_cast<mrpt::utils::VerbosityLevel>(loggers["ros.roscpp"]));
   if (loggers.find("ros.mrpt_localization") != loggers.end())
     pdf_.setVerbosityLevel(static_cast<mrpt::utils::VerbosityLevel>(loggers["ros.mrpt_localization"]));
+#endif
 }

--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -70,7 +70,7 @@ PFLocalizationNode::Parameters *PFLocalizationNode::param() {
 }
 
 void PFLocalizationNode::init() {
-    // Use MRPT library the same log level as on ROS nodes (only for MRPT_VERSION >= 0x130)
+    // Use MRPT library the same log level as on ROS nodes (only for MRPT_VERSION >= 0x150)
     useROSLogLevel();
 
     PFLocalization::init();
@@ -380,7 +380,7 @@ void PFLocalizationNode::publishPose() {
 }
 
 void PFLocalizationNode::useROSLogLevel() {
-#if MRPT_VERSION>=0x130
+#if MRPT_VERSION>=0x150
   // Set ROS log level also on MRPT internal log system; level enums are fully compatible
   std::map<std::string, ros::console::levels::Level> loggers;
   ros::console::get_loggers(loggers);

--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -354,6 +354,8 @@ void PFLocalizationNode::publishPose() {
   // Fill in the header
   mrpt_bridge::convert(timeLastUpdate_, p.header.stamp) ;
   p.header.frame_id = tf::resolve(param()->tf_prefix, param()->global_frame_id) ;
+  if (loop_count_ == 0)
+    p.header.stamp = ros::Time::now();  // on first iteration timestamp is nonsense
 
   // Copy in the pose
   mrpt_bridge::convert(mean, p.pose.pose) ;


### PR DESCRIPTION
Put the ROS log setting withing if MRPT_VERSION>=0x130 so it doesn't break the compilation agains .deb mrpt libs

Also includes a minimal fix to the first mrpt_pose published