### PR TITLE
Add Pose2DStamped ROS message

### DIFF
--- a/mrpt_msgs/CMakeLists.txt
+++ b/mrpt_msgs/CMakeLists.txt
@@ -9,7 +9,9 @@ add_message_files(
   ObservationRangeBearing.msg
   ObservationRangeBeacon.msg
   SingleRangeBearingObservation.msg
-  SingleRangeBeaconObservation.msg)
+  SingleRangeBeaconObservation.msg
+  Pose2DStamped.msg
+  )
 
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 

--- a/mrpt_msgs/msg/Pose2DStamped.msg
+++ b/mrpt_msgs/msg/Pose2DStamped.msg
@@ -1,0 +1,7 @@
+# Message defines a stamped Pose2D message based on geometry_msgs/Pose2D
+
+Header header
+geometry_msgs/Pose2D pose
+
+
+


### PR DESCRIPTION
@jlblancoc This is a (custom) msg that is included in the demo rosbag. I think I should have used a standard geometry_msgs::PoseStamped message but nonetheless I am making this PR just for the mrpt_slam package to compile successfully. I 'll replace this msg, first chance possible.  