### PR TITLE
Use ros::Time::now() to time stamp first 10 poses

### DIFF
--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -421,8 +421,8 @@ void PFLocalizationNode::publishPose()
   // Fill in the header
   mrpt_bridge::convert(timeLastUpdate_, p.header.stamp);
   p.header.frame_id = tf::resolve(param()->tf_prefix, param()->global_frame_id);
-  if (loop_count_ == 0)
-    p.header.stamp = ros::Time::now();  // on first iteration timestamp is nonsense
+  if (loop_count_ < 10)
+    p.header.stamp = ros::Time::now();  // on first iterations timestamp differs a lot from ROS time
 
   // Copy in the pose
   mrpt_bridge::convert(mean, p.pose.pose);


### PR DESCRIPTION
If not, they contain wall time, what when working on simulation prevents robot_localization fusion to work.

Other than that, the change is innocuous