### PR TITLE
Fix bug in MRPT->ROS pose conversion

### DIFF
--- a/mrpt_bridge/CMakeLists.txt
+++ b/mrpt_bridge/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(${PROJECT_NAME}
   src/map.cpp
   src/beacon.cpp
   src/landmark.cpp
+  src/network_of_poses.cpp
 )
 
 ## Declare a cpp executable

--- a/mrpt_bridge/include/mrpt_bridge/network_of_poses.h
+++ b/mrpt_bridge/include/mrpt_bridge/network_of_poses.h
@@ -23,17 +23,27 @@
 #include <mrpt/graphs/CNetworkOfPoses.h>
 #include <mrpt/math/CMatrix.h>
 #include <mrpt/utils/types_simple.h>
+#include <mrpt/system/os.h>
 
 #include "mrpt_bridge/pose.h"
+
+#include <iostream> // for debugging reasons
 
 namespace mrpt_bridge {
 
 /**\name ROS \rightarrow MRPT conversions */
-/**\brief Convert [MRPT] CNetworkOfPoses*DInf \rightarrow [ROS] NetworkOfPoses.
+/**\brief Convert [MRPT] CNetworkOfPoses*D \rightarrow [ROS] NetworkOfPoses.
  * \param[in] mrpt_graph MRPT graph representation
  * \param[out] ros_graph ROS graph representation
  */
 /**\{*/
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses2D& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph);
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses3D& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph);
 
 bool convert(
 		const mrpt::graphs::CNetworkOfPoses2DInf& mrpt_graph,

--- a/mrpt_bridge/include/mrpt_bridge/network_of_poses.h
+++ b/mrpt_bridge/include/mrpt_bridge/network_of_poses.h
@@ -15,19 +15,8 @@
 #ifndef NETWORK_OF_POSES_H
 #define NETWORK_OF_POSES_H
 
-#include <geometry_msgs/Pose.h>
-#include <geometry_msgs/PoseWithCovariance.h>
 #include <mrpt_msgs/NetworkOfPoses.h>
-#include <mrpt_msgs/NodeIDWithPose.h>
-
 #include <mrpt/graphs/CNetworkOfPoses.h>
-#include <mrpt/math/CMatrix.h>
-#include <mrpt/utils/types_simple.h>
-#include <mrpt/system/os.h>
-
-#include "mrpt_bridge/pose.h"
-
-#include <iostream> // for debugging reasons
 
 namespace mrpt_bridge {
 
@@ -61,6 +50,13 @@ bool convert(
  * \param[out] ros_graph MRPT graph representation
  */
 /**\{ */
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses2D& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph);
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses3D& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph);
 
 bool convert(
 		const mrpt_msgs::NetworkOfPoses& ros_graph,

--- a/mrpt_bridge/include/mrpt_bridge/network_of_poses.h
+++ b/mrpt_bridge/include/mrpt_bridge/network_of_poses.h
@@ -1,0 +1,67 @@
+/* +---------------------------------------------------------------------------+
+	 |                     Mobile Robot Programming Toolkit (MRPT)               |
+	 |                          http://www.mrpt.org/                             |
+	 |                                                                           |
+	 | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+	 | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+	 | Released under BSD License. See details in http://www.mrpt.org/License    |
+	 +---------------------------------------------------------------------------+ */
+
+/**
+ * File includes methods for converting CNetworkOfPoses*DInf <=> NetworkOfPoses
+ * message types
+ */
+
+#ifndef NETWORK_OF_POSES_H
+#define NETWORK_OF_POSES_H
+
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseWithCovariance.h>
+#include <mrpt_msgs/NetworkOfPoses.h>
+#include <mrpt_msgs/NodeIDWithPose.h>
+
+#include <mrpt/graphs/CNetworkOfPoses.h>
+#include <mrpt/math/CMatrix.h>
+#include <mrpt/utils/types_simple.h>
+
+#include "mrpt_bridge/pose.h"
+
+namespace mrpt_bridge {
+
+/**\name ROS \rightarrow MRPT conversions */
+/**\brief Convert [MRPT] CNetworkOfPoses*DInf \rightarrow [ROS] NetworkOfPoses.
+ * \param[in] mrpt_graph MRPT graph representation
+ * \param[out] ros_graph ROS graph representation
+ */
+/**\{*/
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses2DInf& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph);
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph);
+
+/**\} */
+
+/**\name ROS \rightarrow MRPT conversions */
+/**\brief Convert [ROS] NetworkOfPoses \rightarrow [MRPT] CNetworkOfPoses*DInf.
+ * \param[in] mrpt_graph ROS graph representation
+ * \param[out] ros_graph MRPT graph representation
+ */
+/**\{ */
+
+bool convert(
+		const mrpt_msgs::NetworkOfPoses& ros_graph,
+		mrpt::graphs::CNetworkOfPoses2DInf& mrpt_graph);
+
+bool convert(
+		const mrpt_msgs::NetworkOfPoses& ros_graph,
+		mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph);
+
+/**\} */
+
+} // end of namespace - mrpt_bridge
+
+#endif /* end of include guard: NETWORK_OF_POSES_H */

--- a/mrpt_bridge/include/mrpt_bridge/pose.h
+++ b/mrpt_bridge/include/mrpt_bridge/pose.h
@@ -44,34 +44,54 @@ namespace mrpt_bridge
 	/**\{ */
 
 	/** Convert: [MRPT] Matrix \rightarrow [ROS] Matrix */
-	tf::Matrix3x3& convert(const mrpt::math::CMatrixDouble33& _src, tf::Matrix3x3& _des);
+	tf::Matrix3x3& convert(
+			const mrpt::math::CMatrixDouble33& _src,
+			tf::Matrix3x3& _des);
 
 	/** Convert: [MRPT] CPose3D \rightarrow [ROS] Transform */
-	tf::Transform& convert(const mrpt::poses::CPose3D& _src, tf::Transform&  _des);
+	tf::Transform& convert(
+			const mrpt::poses::CPose3D& _src,
+			tf::Transform&  _des);
 
 	/** Convert: [MRPT] CPose3D \rightarrow [ROS] Pose */
-	geometry_msgs::Pose&  convert(const mrpt::poses::CPose3D& _src, geometry_msgs::Pose& _des);
+	geometry_msgs::Pose&  convert(
+			const mrpt::poses::CPose3D& _src,
+			geometry_msgs::Pose& _des);
 
 	/** Convert: [MRPT] CPose2D (x,y,yaw) \rightarrow [ROS] Pose */
-	geometry_msgs::Pose& convert(const mrpt::poses::CPose2D& _src, geometry_msgs::Pose& _des);
+	geometry_msgs::Pose& convert(
+			const mrpt::poses::CPose2D& _src,
+			geometry_msgs::Pose& _des);
 
 	/** Convert: [MRPT] CPose3DPDFGaussian \rightarrow [ROS] PoseWithCovariance */
-	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPose3DPDFGaussian& _src, geometry_msgs::PoseWithCovariance& _des);
+	geometry_msgs::PoseWithCovariance& convert(
+			const mrpt::poses::CPose3DPDFGaussian& _src,
+			geometry_msgs::PoseWithCovariance& _des);
 
 	/** Convert: [MRPT] CPose3DPDFGaussianInf \rightarrow [ROS] PoseWithCovariance */
-	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPose3DPDFGaussianInf& _src, geometry_msgs::PoseWithCovariance& _des);
+	geometry_msgs::PoseWithCovariance& convert(
+			const mrpt::poses::CPose3DPDFGaussianInf& _src,
+			geometry_msgs::PoseWithCovariance& _des);
 
 	/** Convert: [MRPT] CPose3DPDFGaussian \rightarrow [ROS] Transform */
-	tf::Transform& convert(const mrpt::poses::CPose3DPDFGaussian& _src, tf::Transform& _des);
+	tf::Transform& convert(
+			const mrpt::poses::CPose3DPDFGaussian& _src,
+			tf::Transform& _des);
 
 	/** Convert: [MRPT] CPosePDFGaussian (x,y,yaw) \rightarrow [ROS] PoseWithCovariance */
-	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPosePDFGaussian& _src, geometry_msgs::PoseWithCovariance& _des);
+	geometry_msgs::PoseWithCovariance& convert(
+			const mrpt::poses::CPosePDFGaussian& _src,
+			geometry_msgs::PoseWithCovariance& _des);
 
 	/** Convert: [MRPT] CPosePDFGaussianInf (x,y,yaw) \rightarrow [ROS] PoseWithCovariance */
-	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPosePDFGaussianInf& _src, geometry_msgs::PoseWithCovariance& _des);
+	geometry_msgs::PoseWithCovariance& convert(
+			const mrpt::poses::CPosePDFGaussianInf& _src,
+			geometry_msgs::PoseWithCovariance& _des);
 
 	/** Convert: [MRPT] CQuaternionDouble \rightarrow [ROS] Quaternion  */
-	geometry_msgs::Quaternion& convert(const mrpt::poses::CQuaternionDouble& _src, geometry_msgs::Quaternion& _des);
+	geometry_msgs::Quaternion& convert(
+			const mrpt::poses::CQuaternionDouble& _src,
+			geometry_msgs::Quaternion& _des);
 
 	/**\} */
 
@@ -79,31 +99,49 @@ namespace mrpt_bridge
 	/**\{ */
 
 	/** Convert: [ROS] CPose3D \rightarrow [MRPT] Transform */
-	mrpt::poses::CPose3D& convert(const tf::Transform& _src, mrpt::poses::CPose3D& _des);
+	mrpt::poses::CPose3D& convert(
+			const tf::Transform& _src,
+			mrpt::poses::CPose3D& _des);
 
 	/** Convert: [ROS] Matrix \rightarrow [MRPT] Matrix */
-	mrpt::math::CMatrixDouble33& convert(const tf::Matrix3x3& _src, mrpt::math::CMatrixDouble33& _des);
+	mrpt::math::CMatrixDouble33& convert(
+			const tf::Matrix3x3& _src,
+			mrpt::math::CMatrixDouble33& _des);
 
 	/** Convert: [ROS] Pose \rightarrow [MRPT] CPose2D  */
-	mrpt::poses::CPose2D& convert(const geometry_msgs::Pose& _src, mrpt::poses::CPose2D& _des);
+	mrpt::poses::CPose2D& convert(
+			const geometry_msgs::Pose& _src,
+			mrpt::poses::CPose2D& _des);
 
 	/** Convert: [ROS] Pose \rightarrow [MRPT] CPose3D  */
-	mrpt::poses::CPose3D& convert(const geometry_msgs::Pose& _src, mrpt::poses::CPose3D& _des);
+	mrpt::poses::CPose3D& convert(
+			const geometry_msgs::Pose& _src,
+			mrpt::poses::CPose3D& _des);
 
 	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPose3DPDFGaussian */
-	mrpt::poses::CPose3DPDFGaussian& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPose3DPDFGaussian& _des);
+	mrpt::poses::CPose3DPDFGaussian& convert(
+			const geometry_msgs::PoseWithCovariance& _src,
+			mrpt::poses::CPose3DPDFGaussian& _des);
 
 	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPose3DPDFGaussianInf */
-	mrpt::poses::CPose3DPDFGaussianInf& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPose3DPDFGaussianInf& _des);
+	mrpt::poses::CPose3DPDFGaussianInf& convert(
+			const geometry_msgs::PoseWithCovariance& _src,
+			mrpt::poses::CPose3DPDFGaussianInf& _des);
 
 	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPosePDFGaussian (x,y,yaw) */
-	mrpt::poses::CPosePDFGaussian& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPosePDFGaussian& _des);
+	mrpt::poses::CPosePDFGaussian& convert(
+			const geometry_msgs::PoseWithCovariance& _src,
+			mrpt::poses::CPosePDFGaussian& _des);
 
 	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPosePDFGaussianInf (x,y,yaw) */
-	mrpt::poses::CPosePDFGaussianInf& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPosePDFGaussianInf& _des);
+	mrpt::poses::CPosePDFGaussianInf& convert(
+			const geometry_msgs::PoseWithCovariance& _src,
+			mrpt::poses::CPosePDFGaussianInf& _des);
 
 	/** Convert: [ROS] Quaternion \rightarrow [MRPT] CQuaternionDouble  */
-	mrpt::poses::CQuaternionDouble& convert(const geometry_msgs::Quaternion& _src, mrpt::poses::CQuaternionDouble& _des);
+	mrpt::poses::CQuaternionDouble& convert(
+			const geometry_msgs::Quaternion& _src,
+			mrpt::poses::CQuaternionDouble& _des);
 
 	/**\} */
 

--- a/mrpt_bridge/include/mrpt_bridge/pose.h
+++ b/mrpt_bridge/include/mrpt_bridge/pose.h
@@ -31,56 +31,81 @@ namespace poses{
         class CPose2D;
         class CPose3D;
         class CPosePDFGaussian;
+        class CPosePDFGaussianInf;
         class CPose3DPDFGaussian;
+        class CPose3DPDFGaussianInf;
         typedef math::CQuaternion<double> CQuaternionDouble;
     }
 }
 
 namespace mrpt_bridge
 {
-    /** Convert: ROS's Matrix -> MRPT's Matrix */
-    mrpt::math::CMatrixDouble33& convert( const tf::Matrix3x3& _src, mrpt::math::CMatrixDouble33& _des);
+	/**\name MRPT  \rightarrow ROS conversions */
+	/**\{ */
 
-    /** Convert: MRPT's Matrix -> Matrix */
-    tf::Matrix3x3& convert( const mrpt::math::CMatrixDouble33& _src, tf::Matrix3x3& _des);
+	/** Convert: [MRPT] Matrix \rightarrow [ROS] Matrix */
+	tf::Matrix3x3& convert(const mrpt::math::CMatrixDouble33& _src, tf::Matrix3x3& _des);
 
-    /** Convert: MRPT's CPose3D -> ROS's Transform */
-    tf::Transform& convert( const mrpt::poses::CPose3D& _src, tf::Transform&  _des);
-    /** Convert: ROS's CPose3D -> MRPT's Transform */
-    mrpt::poses::CPose3D& convert( const tf::Transform& _src, mrpt::poses::CPose3D& _des);
+	/** Convert: [MRPT] CPose3D \rightarrow [ROS] Transform */
+	tf::Transform& convert(const mrpt::poses::CPose3D& _src, tf::Transform&  _des);
 
-    /** Convert: MRPT's CPose3D -> ROS's Pose */
-    geometry_msgs::Pose&  convert( const mrpt::poses::CPose3D& _src, geometry_msgs::Pose& _des);
+	/** Convert: [MRPT] CPose3D \rightarrow [ROS] Pose */
+	geometry_msgs::Pose&  convert(const mrpt::poses::CPose3D& _src, geometry_msgs::Pose& _des);
 
-	/** Convert: MRPT's CPose2D (x,y,yaw) -> ROS's Pose */
-    geometry_msgs::Pose& convert( const mrpt::poses::CPose2D& _src, geometry_msgs::Pose& _des);
+	/** Convert: [MRPT] CPose2D (x,y,yaw) \rightarrow [ROS] Pose */
+	geometry_msgs::Pose& convert(const mrpt::poses::CPose2D& _src, geometry_msgs::Pose& _des);
 
-	/** Convert: MRPT's CPose3DPDFGaussian -> ROS's PoseWithCovariance */
-    geometry_msgs::PoseWithCovariance& convert( const mrpt::poses::CPose3DPDFGaussian& _src, geometry_msgs::PoseWithCovariance& _des);
+	/** Convert: [MRPT] CPose3DPDFGaussian \rightarrow [ROS] PoseWithCovariance */
+	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPose3DPDFGaussian& _src, geometry_msgs::PoseWithCovariance& _des);
 
-    /** Convert: MRPT's CPose3DPDFGaussian -> ROS's Transform */
-    tf::Transform& convert( const mrpt::poses::CPose3DPDFGaussian& _src, tf::Transform&);
+	/** Convert: [MRPT] CPose3DPDFGaussianInf \rightarrow [ROS] PoseWithCovariance */
+	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPose3DPDFGaussianInf& _src, geometry_msgs::PoseWithCovariance& _des);
 
-	/** Convert: MRPT's CPosePDFGaussian (x,y,yaw) -> ROS's PoseWithCovariance */
-    geometry_msgs::PoseWithCovariance& convert( const mrpt::poses::CPosePDFGaussian& _src, geometry_msgs::PoseWithCovariance& _des);
+	/** Convert: [MRPT] CPose3DPDFGaussian \rightarrow [ROS] Transform */
+	tf::Transform& convert(const mrpt::poses::CPose3DPDFGaussian& _src, tf::Transform& _des);
 
-	/** Convert: MRPT's CQuaternionDouble -> ROS's Quaternion  */
-    geometry_msgs::Quaternion& convert(  const mrpt::poses::CQuaternionDouble& _src, geometry_msgs::Quaternion& _des);
+	/** Convert: [MRPT] CPosePDFGaussian (x,y,yaw) \rightarrow [ROS] PoseWithCovariance */
+	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPosePDFGaussian& _src, geometry_msgs::PoseWithCovariance& _des);
 
-	/** Convert: ROS's Pose -> MRPT's CPose2D  */
-    mrpt::poses::CPose2D& convert(const geometry_msgs::Pose& _src, mrpt::poses::CPose2D& _des);
+	/** Convert: [MRPT] CPosePDFGaussianInf (x,y,yaw) \rightarrow [ROS] PoseWithCovariance */
+	geometry_msgs::PoseWithCovariance& convert(const mrpt::poses::CPosePDFGaussianInf& _src, geometry_msgs::PoseWithCovariance& _des);
 
-	/** Convert: ROS's Pose -> MRPT's CPose3D  */
-    mrpt::poses::CPose3D& convert( const geometry_msgs::Pose& _src, mrpt::poses::CPose3D& _des);
+	/** Convert: [MRPT] CQuaternionDouble \rightarrow [ROS] Quaternion  */
+	geometry_msgs::Quaternion& convert(const mrpt::poses::CQuaternionDouble& _src, geometry_msgs::Quaternion& _des);
 
-	/** Convert: ROS's PoseWithCovariance -> MRPT's CPose3DPDFGaussian */
-    mrpt::poses::CPose3DPDFGaussian& convert( const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPose3DPDFGaussian& _des);
+	/**\} */
 
-	/** Convert: ROS's PoseWithCovariance -> MRPT's CPosePDFGaussian (x,y,yaw) */
-    mrpt::poses::CPosePDFGaussian& convert( const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPosePDFGaussian& _des);
+	/**\name ROS \rightarrow MRPT conversions */
+	/**\{ */
 
-	/** Convert: ROS's Quaternion -> MRPT's CQuaternionDouble  */
-    mrpt::poses::CQuaternionDouble& convert( const geometry_msgs::Quaternion& _src, mrpt::poses::CQuaternionDouble& _des);
+	/** Convert: [ROS] CPose3D \rightarrow [MRPT] Transform */
+	mrpt::poses::CPose3D& convert(const tf::Transform& _src, mrpt::poses::CPose3D& _des);
+
+	/** Convert: [ROS] Matrix \rightarrow [MRPT] Matrix */
+	mrpt::math::CMatrixDouble33& convert(const tf::Matrix3x3& _src, mrpt::math::CMatrixDouble33& _des);
+
+	/** Convert: [ROS] Pose \rightarrow [MRPT] CPose2D  */
+	mrpt::poses::CPose2D& convert(const geometry_msgs::Pose& _src, mrpt::poses::CPose2D& _des);
+
+	/** Convert: [ROS] Pose \rightarrow [MRPT] CPose3D  */
+	mrpt::poses::CPose3D& convert(const geometry_msgs::Pose& _src, mrpt::poses::CPose3D& _des);
+
+	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPose3DPDFGaussian */
+	mrpt::poses::CPose3DPDFGaussian& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPose3DPDFGaussian& _des);
+
+	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPose3DPDFGaussianInf */
+	mrpt::poses::CPose3DPDFGaussianInf& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPose3DPDFGaussianInf& _des);
+
+	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPosePDFGaussian (x,y,yaw) */
+	mrpt::poses::CPosePDFGaussian& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPosePDFGaussian& _des);
+
+	/** Convert: [ROS] PoseWithCovariance \rightarrow [MRPT] CPosePDFGaussianInf (x,y,yaw) */
+	mrpt::poses::CPosePDFGaussianInf& convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPosePDFGaussianInf& _des);
+
+	/** Convert: [ROS] Quaternion \rightarrow [MRPT] CQuaternionDouble  */
+	mrpt::poses::CQuaternionDouble& convert(const geometry_msgs::Quaternion& _src, mrpt::poses::CQuaternionDouble& _des);
+
+	/**\} */
 
 }
 

--- a/mrpt_bridge/include/mrpt_bridge/utils.h
+++ b/mrpt_bridge/include/mrpt_bridge/utils.h
@@ -44,7 +44,7 @@ namespace mrpt_bridge {
 	}
 
 	/**
-   * @brief callback that is called by MRPT mrpt::utils::COuputLogger to refirect log messages to ROS logger.
+   * @brief callback that is called by MRPT mrpt::utils::COuputLogger to redirect log messages to ROS logger.
    * 	This function has to be inline, otherwise option log4j.logger.ros.package_name will be taken from mrpt_bridge
    *  instead of the package from which macro is actually called.
    */

--- a/mrpt_bridge/src/network_of_poses.cpp
+++ b/mrpt_bridge/src/network_of_poses.cpp
@@ -1,0 +1,134 @@
+/* +---------------------------------------------------------------------------+
+	 |                     Mobile Robot Programming Toolkit (MRPT)               |
+	 |                          http://www.mrpt.org/                             |
+	 |                                                                           |
+	 | Copyright (c) 2005-2016, Individual contributors, see AUTHORS file        |
+	 | See: http://www.mrpt.org/Authors - All rights reserved.                   |
+	 | Released under BSD License. See details in http://www.mrpt.org/License    |
+	 +---------------------------------------------------------------------------+ */
+
+#include "mrpt_bridge/network_of_poses.h"
+
+namespace mrpt_bridge {
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses2DInf& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph) {
+	using namespace geometry_msgs;
+	using namespace mrpt::math;
+	using namespace mrpt::graphs;
+	using namespace mrpt::poses;
+
+	typedef typename mrpt::graphs::CNetworkOfPoses2DInf::global_poses_t::const_iterator poses_cit_t;
+
+	const CNetworkOfPoses2DInf::BASE::edges_map_t& constraints =
+		mrpt_graph.BASE::edges;
+
+	// fill root node
+	ros_graph.root = mrpt_graph.root;
+	
+	// fill nodeIDs, positions
+	for (poses_cit_t poses_cit = mrpt_graph.nodes.begin();
+			poses_cit != mrpt_graph.nodes.end();
+			++poses_cit) {
+
+		mrpt_msgs::NodeIDWithPose curr_pair;
+
+		// nodeID
+		curr_pair.nodeID = poses_cit->first;
+		// pose
+		convert(poses_cit->second, curr_pair.pose);
+
+		ros_graph.nodes.push_back(curr_pair);
+	}
+
+	// fill the constraints
+	for (CNetworkOfPoses2DInf::const_iterator constr_it = constraints.begin();
+			constr_it != constraints.end();
+			++constr_it) {
+		mrpt_msgs::GraphConstraint ros_constr;
+
+		// constraint ends
+		ros_constr.nodeID_from = constr_it->first.first;
+		ros_constr.nodeID_to = constr_it->first.second;
+
+		// constraint mean and covariance
+		if (mrpt_graph.edges_store_inverse_poses) {
+			CPosePDFGaussianInf constr_inv;
+			constr_it->second.inverse(constr_inv);
+			convert(constr_inv, ros_constr.constraint);
+		}
+		else {
+			convert(constr_it->second, ros_constr.constraint);
+		}
+
+		ros_graph.constraints.push_back(ros_constr);
+	}
+}
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph) {
+	THROW_EXCEPTION("Conversion not yet implemented.");
+	MRPT_TODO("Implement CNetworkOfPoses3DInf => mrpt_msgs::NetworkOfPoses conversion.");
+}
+
+bool convert(
+		const mrpt_msgs::NetworkOfPoses& ros_graph,
+		mrpt::graphs::CNetworkOfPoses2DInf& mrpt_graph) {
+	using namespace mrpt::utils;
+	using namespace mrpt::poses;
+	using namespace mrpt_msgs;
+	using namespace std;
+
+	typedef NetworkOfPoses::_nodes_type::const_iterator nodes_cit_t;
+	typedef NetworkOfPoses::_constraints_type::const_iterator constraints_cit_t;
+
+	// fill root node
+	mrpt_graph.root = ros_graph.root;
+
+	// fill nodeIDs, positions
+	for (nodes_cit_t nodes_cit = ros_graph.nodes.begin();
+			nodes_cit != ros_graph.nodes.end();
+			++nodes_cit) {
+
+		// get the pose
+		CPose2D mrpt_pose;
+		convert(nodes_cit->pose, mrpt_pose);
+
+		mrpt_graph.nodes.insert(make_pair(
+					static_cast<TNodeID>(nodes_cit->nodeID),
+					mrpt_pose));
+	}
+
+	// fill the constraints
+	for (constraints_cit_t constr_cit = ros_graph.constraints.begin();
+			constr_cit != ros_graph.constraints.end();
+			++constr_cit) {
+
+		// constraint ends
+		TPairNodeIDs constr_ends(make_pair(
+					static_cast<TNodeID>(constr_cit->nodeID_from),
+					static_cast<TNodeID>(constr_cit->nodeID_to)));
+		
+		// constraint value
+		mrpt::poses::CPosePDFGaussianInf mrpt_constr;
+		convert(constr_cit->constraint, mrpt_constr);
+
+		mrpt_graph.edges.insert(make_pair(constr_ends, mrpt_constr));
+	}
+
+	mrpt_graph.edges_store_inverse_poses = false;
+
+}
+
+bool convert(
+		const mrpt_msgs::NetworkOfPoses& ros_graph,
+		mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph) {
+	THROW_EXCEPTION("Conversion not yet implemented.");
+	MRPT_TODO("Implement mrpt_msgs::NetworkOfPoses => CNetworkOfPoses3DInf conversion.");
+}
+
+} // end of namespace
+
+

--- a/mrpt_bridge/src/network_of_poses.cpp
+++ b/mrpt_bridge/src/network_of_poses.cpp
@@ -11,6 +11,10 @@
 
 namespace mrpt_bridge {
 
+///////////////////////////////////////////////////////////////////////////////////////////
+// MRPT => ROS
+///////////////////////////////////////////////////////////////////////////////////////////
+
 bool convert(
 		const mrpt::graphs::CNetworkOfPoses2DInf& mrpt_graph,
 		mrpt_msgs::NetworkOfPoses& ros_graph) {
@@ -18,6 +22,7 @@ bool convert(
 	using namespace mrpt::math;
 	using namespace mrpt::graphs;
 	using namespace mrpt::poses;
+	using namespace std;
 
 	typedef typename mrpt::graphs::CNetworkOfPoses2DInf::global_poses_t::const_iterator poses_cit_t;
 
@@ -61,6 +66,7 @@ bool convert(
 		else {
 			convert(constr_it->second, ros_constr.constraint);
 		}
+		mrpt::system::pause();
 
 		ros_graph.constraints.push_back(ros_constr);
 	}
@@ -72,6 +78,22 @@ bool convert(
 	THROW_EXCEPTION("Conversion not yet implemented.");
 	MRPT_TODO("Implement CNetworkOfPoses3DInf => mrpt_msgs::NetworkOfPoses conversion.");
 }
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses2D& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph) {
+	THROW_EXCEPTION("Conversion not yet implemented.");
+}
+
+bool convert(
+		const mrpt::graphs::CNetworkOfPoses3D& mrpt_graph,
+		mrpt_msgs::NetworkOfPoses& ros_graph) {
+	THROW_EXCEPTION("Conversion not yet implemented.");
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////
+// ROS => MRPT
+///////////////////////////////////////////////////////////////////////////////////////////
 
 bool convert(
 		const mrpt_msgs::NetworkOfPoses& ros_graph,

--- a/mrpt_bridge/src/network_of_poses.cpp
+++ b/mrpt_bridge/src/network_of_poses.cpp
@@ -8,6 +8,15 @@
 	 +---------------------------------------------------------------------------+ */
 
 #include "mrpt_bridge/network_of_poses.h"
+#include "mrpt_bridge/pose.h"
+
+#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/PoseWithCovariance.h>
+#include <mrpt_msgs/NodeIDWithPose.h>
+
+#include <mrpt/utils/types_simple.h>
+
+#include <iostream> // for debugging reasons
 
 namespace mrpt_bridge {
 
@@ -149,6 +158,18 @@ bool convert(
 		mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph) {
 	THROW_EXCEPTION("Conversion not yet implemented.");
 	MRPT_TODO("Implement mrpt_msgs::NetworkOfPoses => CNetworkOfPoses3DInf conversion.");
+}
+
+bool convert(
+		mrpt_msgs::NetworkOfPoses& ros_graph,
+		const mrpt::graphs::CNetworkOfPoses2D& mrpt_graph) {
+	THROW_EXCEPTION("Conversion not yet implemented.");
+}
+
+bool convert(
+		mrpt_msgs::NetworkOfPoses& ros_graph,
+		const mrpt::graphs::CNetworkOfPoses3D& mrpt_graph) {
+	THROW_EXCEPTION("Conversion not yet implemented.");
 }
 
 } // end of namespace

--- a/mrpt_bridge/src/pose.cpp
+++ b/mrpt_bridge/src/pose.cpp
@@ -170,22 +170,25 @@ geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(const mrpt::poses::CPose
   // Old comment: "MRPT uses non-fixed axis for 6x6 covariance: should use a transform Jacobian here!"
   //           JL ==> Nope! non-fixed z-y-x equals fixed x-y-z rotations.
 
-  for (int i = 0; i < 6; i++) {
-    for (int j = 0; j < 6; j++) {
-      double cov_val;
-      int ros_i = i;
-      int ros_j = j;
-      if (i > 2 || j > 2)
-        cov_val = 0;
-      else
-      {
-        ros_i = i == 2 ? 5 : i;
-        ros_j = j == 2 ? 5 : j;
-        cov_val = _src.cov(i, j);
-      }
-      _des.covariance[ros_i * 6 + ros_j] = cov_val;
-    }
-  }
+	// geometry_msgs/PoseWithCovariance msg stores the covariance matrix in row-major representation
+	// Indexes are :
+	// [ 0   1   2   3   4   5  ]
+	// [ 6   7   8   9   10  11 ]
+	// [ 12  13  14  15  16  17 ]
+	// [ 18  19  20  21  22  23 ]
+	// [ 24  25  26  27  28  29 ]
+	// [ 30  31  32  33  34  35 ]
+
+	_des.covariance[0]  = _src.cov(0, 0);
+	_des.covariance[1]  = _src.cov(0, 1);
+	_des.covariance[5]  = _src.cov(0, 2);
+	_des.covariance[6]  = _src.cov(1, 0);
+	_des.covariance[7]  = _src.cov(1, 1);
+	_des.covariance[11] = _src.cov(1, 2);
+	_des.covariance[30] = _src.cov(2, 0);
+	_des.covariance[31] = _src.cov(2, 1);
+	_des.covariance[35] = _src.cov(2, 2);
+
   return _des;
 }
 

--- a/mrpt_bridge/src/pose.cpp
+++ b/mrpt_bridge/src/pose.cpp
@@ -33,25 +33,37 @@
 #include <tf/tf.h>
 #include "mrpt_bridge/pose.h"
 
-mrpt::math::CMatrixDouble33& mrpt_bridge::convert(const tf::Matrix3x3& _src, mrpt::math::CMatrixDouble33& _des){
-    for(int r = 0; r < 3; r++)
-        for(int c = 0; c < 3; c++)
-            _des(r,c) = _src[r][c];
-    return _des;
+mrpt::math::CMatrixDouble33& mrpt_bridge::convert(
+		const tf::Matrix3x3& _src,
+		mrpt::math::CMatrixDouble33& _des){
+
+  for(int r = 0; r < 3; r++)
+    for(int c = 0; c < 3; c++)
+      _des(r,c) = _src[r][c];
+  return _des;
 }
 
-tf::Matrix3x3& mrpt_bridge::convert(const mrpt::math::CMatrixDouble33& _src, tf::Matrix3x3& _des){
-    for(int r = 0; r < 3; r++)
-        for(int c = 0; c < 3; c++)
-             _des[r][c] = _src(r,c);
-    return _des;
+tf::Matrix3x3& mrpt_bridge::convert(
+		const mrpt::math::CMatrixDouble33& _src,
+		tf::Matrix3x3& _des){
+
+  for(int r = 0; r < 3; r++)
+    for(int c = 0; c < 3; c++)
+      _des[r][c] = _src(r,c);
+  return _des;
 }
 
-tf::Transform& mrpt_bridge::convert(const mrpt::poses::CPose3DPDFGaussian& _src, tf::Transform& _des){
-    return convert(_src.mean, _des);
+tf::Transform& mrpt_bridge::convert(
+		const mrpt::poses::CPose3DPDFGaussian& _src,
+		tf::Transform& _des){
+
+  return convert(_src.mean, _des);
 }
 
-geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(const mrpt::poses::CPose3DPDFGaussian& _src, geometry_msgs::PoseWithCovariance& _des) {
+geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(
+		const mrpt::poses::CPose3DPDFGaussian& _src,
+		geometry_msgs::PoseWithCovariance& _des) {
+
   convert(_src.mean, _des.pose);
 
   // Read REP103: http://ros.org/reps/rep-0103.html#covariance-representation
@@ -85,23 +97,28 @@ geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(
 
 }
 
-tf::Transform& mrpt_bridge::convert(const mrpt::poses::CPose3D& _src, tf::Transform& _des) {
-    tf::Vector3 origin(_src[0], _src[1], _src[2]);
-    mrpt::math::CMatrixDouble33 R;
-    _src.getRotationMatrix(R);
-    tf::Matrix3x3 basis;
-    _des.setBasis(convert(R,basis));
-    _des.setOrigin(origin);
-    return _des;
+tf::Transform& mrpt_bridge::convert(
+		const mrpt::poses::CPose3D& _src,
+		tf::Transform& _des) {
+
+  tf::Vector3 origin(_src[0], _src[1], _src[2]);
+  mrpt::math::CMatrixDouble33 R;
+  _src.getRotationMatrix(R);
+  tf::Matrix3x3 basis;
+  _des.setBasis(convert(R,basis));
+  _des.setOrigin(origin);
+
+  return _des;
 }
 mrpt::poses::CPose3D& mrpt_bridge::convert(const tf::Transform& _src, mrpt::poses::CPose3D& _des){
-    const tf::Vector3 &t = _src.getOrigin();
-    _des.x() = t[0], _des.y() = t[1], _des.z() = t[2];
-    const tf::Matrix3x3 &basis = _src.getBasis();
-    mrpt::math::CMatrixDouble33 R;
-    convert(basis, R);
-    _des.setRotationMatrix(R);
-    return _des;
+  const tf::Vector3 &t = _src.getOrigin();
+  _des.x() = t[0], _des.y() = t[1], _des.z() = t[2];
+  const tf::Matrix3x3 &basis = _src.getBasis();
+  mrpt::math::CMatrixDouble33 R;
+  convert(basis, R);
+  _des.setRotationMatrix(R);
+
+  return _des;
 }
 
 geometry_msgs::Pose& mrpt_bridge::convert(const mrpt::poses::CPose3D& _src, geometry_msgs::Pose& _des)
@@ -117,6 +134,7 @@ geometry_msgs::Pose& mrpt_bridge::convert(const mrpt::poses::CPose3D& _src, geom
   _des.orientation.y = q.y();
   _des.orientation.z = q.z();
   _des.orientation.w = q.r();
+
   return _des;
 }
 
@@ -144,6 +162,7 @@ geometry_msgs::Pose& mrpt_bridge::convert(const mrpt::poses::CPose2D& _src, geom
     _des.orientation.z = s;
     _des.orientation.w = c;
   }
+
   return _des;
 }
 
@@ -159,6 +178,7 @@ mrpt::poses::CPose2D& mrpt_bridge::convert(const geometry_msgs::Pose& _src, mrpt
   quat.rpy(roll, pitch, yaw);
 
   _des.phi(yaw);
+
   return _des;
 }
 
@@ -192,8 +212,9 @@ geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(const mrpt::poses::CPose
   return _des;
 }
 
-geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(const mrpt::poses::CPosePDFGaussianInf& _src, geometry_msgs::PoseWithCovariance& _des)
-{
+geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(
+		const mrpt::poses::CPosePDFGaussianInf& _src,
+		geometry_msgs::PoseWithCovariance& _des) {
 	mrpt::poses::CPosePDFGaussian mrpt_gaussian;
 	mrpt_gaussian.copyFrom(_src);
 
@@ -202,8 +223,9 @@ geometry_msgs::PoseWithCovariance& mrpt_bridge::convert(const mrpt::poses::CPose
 }
 
 
-mrpt::poses::CPose3DPDFGaussian& mrpt_bridge::convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPose3DPDFGaussian& _des)
-{
+mrpt::poses::CPose3DPDFGaussian& mrpt_bridge::convert(
+		const geometry_msgs::PoseWithCovariance& _src,
+		mrpt::poses::CPose3DPDFGaussian& _des) {
   convert(_src.pose, _des.mean);
 
   const unsigned int indxs_map[6] = {0, 1, 2, 5, 4, 3};
@@ -217,7 +239,10 @@ mrpt::poses::CPose3DPDFGaussian& mrpt_bridge::convert(const geometry_msgs::PoseW
   return _des;
 }
 
-mrpt::poses::CPose3DPDFGaussianInf& mrpt_bridge::convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPose3DPDFGaussianInf& _des) {
+mrpt::poses::CPose3DPDFGaussianInf& mrpt_bridge::convert(
+		const geometry_msgs::PoseWithCovariance& _src,
+		mrpt::poses::CPose3DPDFGaussianInf& _des) {
+
 	mrpt::poses::CPose3DPDFGaussian mrpt_gaussian;
 	convert(_src, mrpt_gaussian); // Intermediate transform => CPose3DPDFGaussian
 	_des.copyFrom(mrpt_gaussian);
@@ -225,9 +250,12 @@ mrpt::poses::CPose3DPDFGaussianInf& mrpt_bridge::convert(const geometry_msgs::Po
 	return _des;
 }
 
-mrpt::poses::CPosePDFGaussian& mrpt_bridge::convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPosePDFGaussian& _des)
-{
+mrpt::poses::CPosePDFGaussian& mrpt_bridge::convert(
+		const geometry_msgs::PoseWithCovariance& _src,
+		mrpt::poses::CPosePDFGaussian& _des) {
+
   convert(_src.pose, _des.mean);
+
   _des.cov(0, 0) = _src.covariance[0];
   _des.cov(0, 1) = _src.covariance[1];
   _des.cov(0, 2) = _src.covariance[5];
@@ -237,11 +265,14 @@ mrpt::poses::CPosePDFGaussian& mrpt_bridge::convert(const geometry_msgs::PoseWit
   _des.cov(2, 0) = _src.covariance[0+30];
   _des.cov(2, 1) = _src.covariance[1+30];
   _des.cov(2, 2) = _src.covariance[5+30];
+
   return _des;
 }
 
-mrpt::poses::CPosePDFGaussianInf& mrpt_bridge::convert(const geometry_msgs::PoseWithCovariance& _src, mrpt::poses::CPosePDFGaussianInf& _des)
-{
+mrpt::poses::CPosePDFGaussianInf& mrpt_bridge::convert(
+		const geometry_msgs::PoseWithCovariance& _src,
+		mrpt::poses::CPosePDFGaussianInf& _des) {
+
 	mrpt::poses::CPosePDFGaussian mrpt_gaussian;
 	convert(_src, mrpt_gaussian); // intermediate transform: PoseWithCovariance => CPosePDFGaussian
 	_des.copyFrom(mrpt_gaussian);
@@ -249,8 +280,9 @@ mrpt::poses::CPosePDFGaussianInf& mrpt_bridge::convert(const geometry_msgs::Pose
 	return _des;
 }
 
-mrpt::poses::CQuaternionDouble&  mrpt_bridge::convert(const geometry_msgs::Quaternion& _src, mrpt::poses::CQuaternionDouble& _des)
-{
+mrpt::poses::CQuaternionDouble&  mrpt_bridge::convert(
+		const geometry_msgs::Quaternion& _src,
+		mrpt::poses::CQuaternionDouble& _des) {
   _des.x(_src.x);
   _des.y(_src.y);
   _des.z(_src.z);
@@ -258,19 +290,30 @@ mrpt::poses::CQuaternionDouble&  mrpt_bridge::convert(const geometry_msgs::Quate
   return _des;
 }
 
-geometry_msgs::Quaternion& mrpt_bridge::convert(const mrpt::poses::CQuaternionDouble& _src, geometry_msgs::Quaternion& _des)
-{
+geometry_msgs::Quaternion& mrpt_bridge::convert(
+		const mrpt::poses::CQuaternionDouble& _src,
+		geometry_msgs::Quaternion& _des) {
+
   _des.x=_src.x();
   _des.y=_src.y();
   _des.z=_src.z();
   _des.w=_src.r();
+
   return _des;
 }
 
-mrpt::poses::CPose3D& mrpt_bridge::convert(const geometry_msgs::Pose& _src, mrpt::poses::CPose3D& _des)
-{
-  const mrpt::math::CQuaternionDouble q(_src.orientation.w, _src.orientation.x, _src.orientation.y, _src.orientation.z);
-    _des= mrpt::poses::CPose3D(q,_src.position.x,_src.position.y,_src.position.z);
-    return _des;
+mrpt::poses::CPose3D& mrpt_bridge::convert(
+		const geometry_msgs::Pose& _src,
+		mrpt::poses::CPose3D& _des) {
+
+  const mrpt::math::CQuaternionDouble q(
+  		_src.orientation.w,
+  		_src.orientation.x,
+  		_src.orientation.y,
+  		_src.orientation.z);
+  _des= mrpt::poses::CPose3D(q,
+  		_src.position.x, _src.position.y, _src.position.z);
+
+  return _des;
 }
 

--- a/mrpt_msgs/CMakeLists.txt
+++ b/mrpt_msgs/CMakeLists.txt
@@ -10,6 +10,7 @@ add_message_files(
   ObservationRangeBeacon.msg
   SingleRangeBearingObservation.msg
   SingleRangeBeaconObservation.msg
+  GraphSlamStats.msg
   )
 
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)

--- a/mrpt_msgs/CMakeLists.txt
+++ b/mrpt_msgs/CMakeLists.txt
@@ -11,7 +11,19 @@ add_message_files(
   SingleRangeBearingObservation.msg
   SingleRangeBeaconObservation.msg
   GraphSlamStats.msg
+  GraphSlamAgent.msg
+  GraphSlamAgents.msg
+  NodeIDWithPose.msg
+  GraphConstraint.msg
+  NetworkOfPoses.msg
   )
+
+
+ add_service_files(
+   DIRECTORY srv
+   FILES
+   GetCMGraph.srv
+   )
 
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 

--- a/mrpt_msgs/msg/GraphConstraint.msg
+++ b/mrpt_msgs/msg/GraphConstraint.msg
@@ -1,0 +1,7 @@
+# Graph constraint that connects 2 nodes
+#
+# Currently used in the mrpt_graphslam_2d ROS application.
+
+uint64 nodeID_from
+uint64 nodeID_to
+geometry_msgs/PoseWithCovariance constraint

--- a/mrpt_msgs/msg/GraphSlamAgent.msg
+++ b/mrpt_msgs/msg/GraphSlamAgent.msg
@@ -1,0 +1,32 @@
+# Connection-related properties for a graphSLAM agent in a multi-robot
+# environment.
+#
+# Currently used in the mrpt_graphslam_2d ROS application.
+
+std_msgs/String name
+std_msgs/String hostname
+
+# IPv4 of the corresponding agent
+std_msgs/String ip_addr
+
+# Port that the the roscore of the corresponding agent is running under
+uint16 port
+
+# True if the SLAM Agent was last reported to be online
+std_msgs/Bool is_online
+
+# Timestamp that the SLAM Agent was last seen
+std_msgs/Time last_seen_time
+
+# ROS Topics namespace that the agent is running under
+# By definition this is going to be
+# ${name}_${agent_ID} 
+std_msgs/String topic_namespace
+
+# this is the last field of the IPv4 address of the corresponding agent
+# e.g. IP=192.168.100.17
+# agent_ID = 17
+int32 agent_ID 
+
+
+

--- a/mrpt_msgs/msg/GraphSlamAgents.msg
+++ b/mrpt_msgs/msg/GraphSlamAgents.msg
@@ -1,0 +1,5 @@
+# Defines vector of GraphSlamAgents.
+# Currently used in the mrpt_graphslam_2d ROS application.
+
+GraphSlamAgent[] list
+

--- a/mrpt_msgs/msg/GraphSlamStats.msg
+++ b/mrpt_msgs/msg/GraphSlamStats.msg
@@ -1,0 +1,18 @@
+# Statistics related to the execution of graphSLAM.
+# Message is utilized in the mrpt_graphslam ROS package
+
+# Time of message acquisition
+Header header
+
+# node-related stats
+int32 nodes_total
+
+# edge-related stats
+int32 edges_total
+int32 edges_ICP2D
+int32 edges_ICP3D
+int32 edges_odom
+int32 loop_closures
+
+# Evaluation metric of the SLAM process
+float64[] slam_evaluation_metric

--- a/mrpt_msgs/msg/NetworkOfPoses.msg
+++ b/mrpt_msgs/msg/NetworkOfPoses.msg
@@ -1,0 +1,11 @@
+# Represents a 3D Directed Graph of Constraints
+# Currently used in the mrpt_graphslam_2d ROS application.
+#
+# Graph consists of
+# - NodeIDs with their corresponding poses
+# - Directed Constraints that connect 2 nodes with each other
+
+NodeIDWithPose[] nodes
+GraphConstraint[] constraints
+
+

--- a/mrpt_msgs/msg/NetworkOfPoses.msg
+++ b/mrpt_msgs/msg/NetworkOfPoses.msg
@@ -4,7 +4,9 @@
 # Graph consists of
 # - NodeIDs with their corresponding poses
 # - Directed Constraints that connect 2 nodes with each other
+# - Root node marking the start of the graph
 
+uint64 root
 NodeIDWithPose[] nodes
 GraphConstraint[] constraints
 

--- a/mrpt_msgs/msg/NodeIDWithPose.msg
+++ b/mrpt_msgs/msg/NodeIDWithPose.msg
@@ -1,0 +1,7 @@
+# NodeID along with its corresponding 2D/3D pose estimation
+#
+# Currently used in the mrpt_graphslam_2d ROS application.
+
+uint64 nodeID
+geometry_msgs/Pose pose
+

--- a/mrpt_msgs/srv/GetCMGraph.srv
+++ b/mrpt_msgs/srv/GetCMGraph.srv
@@ -1,0 +1,7 @@
+# Compute and return a condensed measurements graph
+# Service is currently used in mrpt_graphslam_2d application
+# Returned graph should, at all cost contain the specified nodes
+
+uint64[] nodeIDs
+---
+mrpt_msgs/NetworkOfPoses cm_graph


### PR DESCRIPTION
@jlblancoc I am sending this PR independent of the multi-robot SLAM algorithm developement as I found a bug in the CPosePDFGaussian => geometry_msgs::PoseWithCovariance conversion.

As you can see in [this](https://github.com/mrpt-ros-pkg/mrpt_navigation/commit/5c037b7d8b45ee70795f59b69b5a6a1d9b499b57) commit when the [x,y,yaw] covariance was transformed into the row-based 3D covariance representation of geometry_msgs/PoseWithCovariance msg, the angle components (elements that had index > 2) were overwritten and the resulting yaw  (element with index 35) was always 0.