### PR TITLE
[mrpt_rawlog] Fix missing rosbag dependency in package.xml.

### DIFF
--- a/mrpt_rawlog/package.xml
+++ b/mrpt_rawlog/package.xml
@@ -21,6 +21,7 @@
   <build_depend>mrpt_msgs</build_depend>
   <build_depend>mrpt_bridge</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>rosbag</build_depend>
   <build_depend>mrpt</build_depend> <!-- Depend on mrpt system pkgs -->
 
   <run_depend>roscpp</run_depend>
@@ -31,6 +32,7 @@
   <run_depend>mrpt_msgs</run_depend>
   <run_depend>mrpt_bridge</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>rosbag</run_depend>
   <run_depend>mrpt</run_depend> <!-- Depend on mrpt system pkgs -->
 
 </package>


### PR DESCRIPTION
That dependency was indicated by doing 
`roslaunch-deps -w mrpt_navigation/mrpt_rawlog/launch/demo_rosbag.launch`