### PR TITLE
rawlog_record: fnc call fileNameStripInvalidChars removed

### DIFF
--- a/mrpt_rawlog/src/rawlog_record_node_parameters.cpp
+++ b/mrpt_rawlog/src/rawlog_record_node_parameters.cpp
@@ -54,8 +54,6 @@ RawlogRecordNode::ParametersNode::ParametersNode(
 	node.param<std::string>("base_frame_id", base_frame_id, "base_link");
 	ROS_INFO("base_frame_id: %s", base_frame_id.c_str());
 	node.getParam("raw_log_folder", base_param_.raw_log_folder);
-	base_param_.raw_log_folder =
-	    mrpt::system::fileNameStripInvalidChars(base_param_.raw_log_folder);
 	ROS_INFO("raw_log_folder: %s", base_param_.raw_log_folder.c_str());
 	reconfigureFnc_ = boost::bind(
 		&RawlogRecordNode::ParametersNode::callbackParameters, this, _1, _2);


### PR DESCRIPTION
fnc call fileNameStripInvalidChars remove. 
Because slashes are on the raw_log_folder paramter replaced by underlines.
This prevented the rawlog to be written

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrpt-ros-pkg/mrpt_navigation/119)
<!-- Reviewable:end -->
