### PR TITLE
add initial pose for localization as param

### DIFF
--- a/mrpt_localization/include/mrpt_localization_node.h
+++ b/mrpt_localization/include/mrpt_localization_node.h
@@ -93,6 +93,9 @@ class PFLocalizationNode : public PFLocalization
 		bool tf_broadcast;
 		bool use_map_topic;
 		bool first_map_only;
+		double init_x; // m
+		double init_y; // m
+		double init_phi; //radians
 	};
 
 	PFLocalizationNode(ros::NodeHandle& n);

--- a/mrpt_localization/src/mrpt_localization_node.cpp
+++ b/mrpt_localization/src/mrpt_localization_node.cpp
@@ -83,6 +83,13 @@ void PFLocalizationNode::init()
 	useROSLogLevel();
 
 	PFLocalization::init();
+	if(param()->init_x || param()->init_y || param()->init_phi)
+	{
+		auto init_pose = mrpt::poses::CPose2D(param()->init_x, param()->init_y, param()->init_phi);
+		initial_pose_ = mrpt::poses::CPosePDFGaussian(init_pose);
+		update_counter_ = 0;
+		state_ = INIT;
+	}
 	sub_init_pose_ = nh_.subscribe(
 		"initialpose", 1, &PFLocalizationNode::callbackInitialpose, this);
 

--- a/mrpt_localization/src/mrpt_localization_node_parameters.cpp
+++ b/mrpt_localization/src/mrpt_localization_node_parameters.cpp
@@ -76,6 +76,12 @@ PFLocalizationNode::Parameters::Parameters(PFLocalizationNode* p)
 	ROS_INFO("first_map_only: %s", first_map_only ? "true" : "false");
 	node.param<bool>("debug", debug, true);
 	ROS_INFO("debug: %s", debug ? "true" : "false");
+	node.param<double>("initial_pose_x", init_x, 0.0);
+	ROS_INFO("initial_pose_x: %f", init_x);
+	node.param<double>("initial_pose_y", init_y, 0.0);
+	ROS_INFO("initial_pose_y: %f", init_y);
+	node.param<double>("initial_pose_phi", init_phi, 0.0); // radians
+	ROS_INFO("initial_pose_phi: %f rad", init_phi);
 
 	reconfigure_cb_ = boost::bind(
 		&PFLocalizationNode::Parameters::callbackParameters, this, _1, _2);


### PR DESCRIPTION
This commit lets the user to define the initial robot position with (x,y, phi) as parameters to the localization node. These parameters can be given to the node through launch file.