### PR TITLE
Implement parallel A* planner; misc bug and style fixes

### DIFF
--- a/mrpt_pf_localization/launch/localization.launch.py
+++ b/mrpt_pf_localization/launch/localization.launch.py
@@ -29,6 +29,12 @@ def generate_launch_description():
 
     use_composable = LaunchConfiguration('use_composable')
 
+    use_composable_arg = DeclareLaunchArgument(
+        'use_composable',
+        default_value='false',
+        description='If true, load as a composable node into container_name instead of a standalone node'
+    )
+
     pf_params_file_launch_arg = DeclareLaunchArgument(
         "pf_params_file", default_value=TextSubstitution(
             text=os.path.join(pfLocDir, 'params', 'default.config.yaml')))
@@ -91,6 +97,7 @@ def generate_launch_description():
     container_name_arg = DeclareLaunchArgument(
         'container_name',
         default_value='',
+        description='Name of the composable node container (required when use_composable:=true)',
     )
 
     pf_localization_node = Node(
@@ -142,6 +149,7 @@ def generate_launch_description():
     )
 
     ld = LaunchDescription([
+        use_composable_arg,
         container_name_arg,
         pf_log_level_launch_arg,
         pf_log_level_core_launch_arg,

--- a/mrpt_pf_localization/launch/localization.launch.py
+++ b/mrpt_pf_localization/launch/localization.launch.py
@@ -164,6 +164,9 @@ def generate_launch_description():
         global_frame_id_arg,
         pf_localization_node,
         composable_pf_localization_node,
+        # Only register the shutdown handler when running as a standalone node.
+        # In composable mode pf_localization_node is never launched so
+        # OnProcessExit would target a non-existent process.
         RegisterEventHandler(
             OnProcessExit(
                 target_action=pf_localization_node,
@@ -171,7 +174,8 @@ def generate_launch_description():
                     LogInfo(msg=('mrpt_pf_localization ended')),
                     EmitEvent(event=Shutdown(
                         reason='mrpt_pf_localization ended'))
-                ])
+                ]),
+            condition=UnlessCondition(use_composable)
         )
     ])
 

--- a/mrpt_pf_localization/src/main.cpp
+++ b/mrpt_pf_localization/src/main.cpp
@@ -6,8 +6,8 @@
    | All rights reserved. Released under BSD 3-Clause license. See LICENSE  |
    +------------------------------------------------------------------------+ */
 
-#include "rclcpp/rclcpp.hpp"
 #include "mrpt_pf_localization_component.cpp"
+#include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char** argv)
 {

--- a/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
@@ -6,8 +6,6 @@
    | All rights reserved. Released under BSD 3-Clause license. See LICENSE  |
    +------------------------------------------------------------------------+ */
 
-#include "mrpt_pf_localization_node.h"
-
 #include <mp2p_icp/metricmap.h>
 #include <mrpt/maps/COccupancyGridMap2D.h>
 #include <mrpt/obs/CObservation2DRangeScan.h>
@@ -27,11 +25,12 @@
 #include <mrpt/version.h>
 #include <pose_cov_ops/pose_cov_ops.h>
 
-#include "rclcpp_components/register_node_macro.hpp"
-
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <mrpt_msgs_bridge/beacon.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include "mrpt_pf_localization_node.h"
+#include "rclcpp_components/register_node_macro.hpp"
 
 #if MRPT_VERSION >= 0x020b08
 #include <mrpt/system/hyperlink.h>
@@ -47,7 +46,7 @@ std::string hyperlink(
 }  // namespace mrpt::system
 #endif
 
-RCLCPP_COMPONENTS_REGISTER_NODE(PFLocalizationNode); //Register node to make it composable
+RCLCPP_COMPONENTS_REGISTER_NODE(PFLocalizationNode);  // Register node to make it composable
 
 PFLocalizationNode::PFLocalizationNode(const rclcpp::NodeOptions& options)
 	: rclcpp::Node("mrpt_pf_localization_node", options)

--- a/mrpt_pointcloud_pipeline/launch/pointcloud_pipeline.launch.py
+++ b/mrpt_pointcloud_pipeline/launch/pointcloud_pipeline.launch.py
@@ -26,6 +26,12 @@ def generate_launch_description():
 
     use_composable = LaunchConfiguration('use_composable')
 
+    use_composable_arg = DeclareLaunchArgument(
+        'use_composable',
+        default_value='false',
+        description='If true, load as a composable node into container_name instead of a standalone node'
+    )
+
     lidar_topic_name_arg = DeclareLaunchArgument(
         'scan_topic_name',
         default_value=''  # /scan, /laser1, etc.
@@ -79,6 +85,7 @@ def generate_launch_description():
     container_name_arg = DeclareLaunchArgument(
         'container_name',
         default_value='',
+        description='Name of the composable node container (required when use_composable:=true)',
     )
 
     emit_shutdown_action = Shutdown(reason='launch is shutting down')
@@ -136,6 +143,7 @@ def generate_launch_description():
     )
 
     ld = LaunchDescription([
+        use_composable_arg,
         container_name_arg,
         lidar_topic_name_arg,
         points_topic_name_arg,

--- a/mrpt_pointcloud_pipeline/src/main.cpp
+++ b/mrpt_pointcloud_pipeline/src/main.cpp
@@ -6,8 +6,8 @@
    | All rights reserved. Released under BSD 3-Clause license. See LICENSE  |
    +------------------------------------------------------------------------+ */
 
-#include "rclcpp/rclcpp.hpp"
 #include "mrpt_pointcloud_pipeline_component.cpp"
+#include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char** argv)
 {

--- a/mrpt_pointcloud_pipeline/src/mrpt_pointcloud_pipeline_component.cpp
+++ b/mrpt_pointcloud_pipeline/src/mrpt_pointcloud_pipeline_component.cpp
@@ -21,7 +21,7 @@ using namespace mrpt::maps;
 using namespace mrpt::obs;
 
 LocalObstaclesNode::LocalObstaclesNode(const rclcpp::NodeOptions& options)
-	:Node("mrpt_pointcloud_pipeline_node", options)
+	: Node("mrpt_pointcloud_pipeline_node", options)
 {
 	m_profiler.setName(Node::get_name());
 

--- a/mrpt_tps_astar_planner/README.md
+++ b/mrpt_tps_astar_planner/README.md
@@ -1,9 +1,20 @@
 # mrpt_tps_astar_planner
 
 ## Overview
-This package provides a ROS 2 node that uses the PTG-based A* planner in mrpt_path_planning
-to publish waypoint sequences moving a non-holonomic robot from A to B, taking into account
-its real shape, orientation, and kinematic constraints.
+
+This package provides a ROS 2 node that uses the PTG-based A\* planner from
+`mrpt_path_planning` to compute collision-free waypoint sequences for a
+non-holonomic robot, respecting its real shape, orientation, and kinematic
+constraints.
+
+Planning is performed on a SE(2) lattice using Parameterized Trajectory
+Generator (PTG) families that encode the robot's motion primitives. The result
+is published as a `mrpt_msgs/WaypointSequence` (and a `nav_msgs/Path` for
+visualization) and/or returned as the response of a ROS 2 service call.
+
+The node supports **concurrent service requests**: each executor thread owns a
+lazily-initialized planner instance, so multiple clients can request plans
+simultaneously without blocking each other.
 
 ## How to cite
 
@@ -14,51 +25,101 @@ its real shape, orientation, and kinematic constraints.
 
 ## Configuration
 
-Write me!
+Key configuration files passed as ROS 2 parameters:
+
+| Parameter | Description |
+|---|---|
+| `ptg_ini` | INI file describing PTG families (robot kinematics) |
+| `planner_parameters` | YAML file with A\* algorithm parameters |
+| `global_costmap_parameters` | YAML file for costmap obstacle-inflation parameters |
+| `prefer_waypoints_parameters` | YAML file for waypoint-preference cost weights |
+
 
 ## Demos
 
-Write me!
+See the `path-planner-sandbox/` subdirectory for standalone test scripts and
+sample maps.
 
-## Node: mrpt_tps_astar_planner_node
+
+## Node: `mrpt_tps_astar_planner_node`
 
 ### Working rationale
 
-Uses A* over a SE(2) lattice and PTGs to sample collision-free paths. The implementation is an anytime algorithm.
+1. Obstacle data are maintained from subscribed gridmaps and/or point-cloud
+   topics (updated asynchronously, protected by a mutex).
+2. On each planning request (topic goal or service call) the node snapshots the
+   current obstacle data, builds cost evaluators, and runs the A\* planner.
+3. The planned path is interpolated at a fixed time step and converted to a
+   `WaypointSequence`.
 
+The A\* implementation is an anytime algorithm: it improves the solution while
+time allows, then returns the best found. An optional refinement pass
+(`astar_skip_refine: false`) further smooths the result.
 
 ### ROS 2 parameters
 
-* `topic_wp_seq_pub` (Default: `/waypoints`) Desired name of the topic in which to publish the calculated paths.
-
-* `topic_goal_sub`: The name of the topic to subscribe for goal poses (`geometry_msgs/PoseStamped`).
-
-* `show_gui`: Shows its own MRPT GUI with the planned paths.
-
-* `topic_gridmap_sub`: One or more (comma separated) topic names to subscribe for occupancy grid maps.
-
-* `topic_obstacle_points_sub`: One or more (comma separated) topic names to subscribe for obstacle points.
-
+| Parameter | Default | Description |
+|---|---|---|
+| `show_gui` | `false` | Open an MRPT 3D window showing maps and the planned path |
+| `frame_id_map` | `map` | TF frame of the global map |
+| `frame_id_robot` | `base_link` | TF frame of the robot |
+| `topic_goal_sub` | `tps_astar_nav_goal` | `geometry_msgs/PoseStamped` goal subscription |
+| `topic_obstacles_gridmap_sub` | _(empty)_ | Comma-separated occupancy-grid topics for obstacles |
+| `topic_obstacles_sub` | _(empty)_ | Comma-separated `PointCloud2` topics for obstacles |
+| `topic_static_maps` | `/map` | Subset of the above topics to subscribe with transient-local QoS |
+| `topic_wp_seq_pub` | `/waypoints` | Topic on which to publish the resulting waypoint sequence |
+| `topic_costmaps_pub` | `/costmap` | Prefix for costmap debug publishers |
+| `ptg_ini` | _(required)_ | Path to PTG `.ini` file |
+| `planner_parameters` | _(required)_ | Path to planner YAML file |
+| `global_costmap_parameters` | _(required)_ | Path to costmap YAML file |
+| `prefer_waypoints_parameters` | _(required)_ | Path to waypoint-preference YAML file |
+| `problem_world_bbox_margin` | `2.0` | Extra margin [m] added around the planning bounding box |
+| `problem_world_bbox_ignore_obstacles` | `false` | If true, obstacle extents are excluded from the bounding box |
+| `astar_skip_refine` | `false` | If true, skip the post-A\* trajectory refinement pass |
+| `mid_waypoints_allowed_distance` | `0.5` | Acceptance radius [m] for intermediate waypoints |
+| `final_waypoint_allowed_distance` | `0.4` | Acceptance radius [m] for the goal waypoint |
+| `mid_waypoints_allow_skip` | `true` | Whether intermediate waypoints may be skipped |
+| `final_waypoint_allow_skip` | `false` | Whether the final waypoint may be skipped |
+| `mid_waypoints_ignore_heading` | `false` | Whether heading is ignored at intermediate waypoints |
+| `final_waypoint_ignore_heading` | `false` | Whether heading is ignored at the final waypoint |
 
 ### Subscribed topics
-* xxx
+
+| Topic | Type | Description |
+|---|---|---|
+| `<topic_goal_sub>` | `geometry_msgs/PoseStamped` | Goal pose; triggers a plan from current TF robot pose |
+| `<topic_obstacles_gridmap_sub>` (one per entry) | `nav_msgs/OccupancyGrid` | Occupancy grid(s) used as static obstacles |
+| `<topic_obstacles_sub>` (one per entry) | `sensor_msgs/PointCloud2` | Point cloud(s) used as dynamic obstacles |
 
 ### Published topics
-* `<topic_wp_seq_pub>`  (Default: `/waypoints`) (`mrpt_msgs::msg::WaypointSequence`): Calculated trajectory, in mrpt_msgs format with complete details for each waypoints.
-* `<topic_wp_seq_pub>_path`  (Default: `/waypoints_path`) (`nav_msgs::msg::Path`): Calculated trajectory, as `nav_msgs::Path`. Mostly useful for visualization only.
+
+| Topic | Type | Description |
+|---|---|---|
+| `<topic_wp_seq_pub>` (default `/waypoints`) | `mrpt_msgs/WaypointSequence` | Full waypoint sequence with per-waypoint tolerances and flags |
+| `<topic_wp_seq_pub>_path` (default `/waypoints_path`) | `nav_msgs/Path` | Same path as `nav_msgs/Path`, mainly for RViz visualization |
+| `<topic_costmaps_pub>_0`, `_1`, … | `nav_msgs/OccupancyGrid` | Inflated costmaps (one per obstacle source), published after each plan |
 
 ### Services
 
-Write me!
+| Service | Type | Description |
+|---|---|---|
+| `<node_fqn>/make_plan_to` | `mrpt_nav_interfaces/MakePlanTo` | Plan from the current robot TF pose to a given goal `PoseStamped`; returns `valid_path_found` and `waypoints` |
+| `<node_fqn>/make_plan_from_to` | `mrpt_nav_interfaces/MakePlanFromTo` | Plan between two explicitly given `Pose` values; no TF lookup needed |
 
-### Template ROS 2 launch files
+Both services are registered in a **reentrant callback group** so multiple
+clients can be served simultaneously by the `MultiThreadedExecutor`.
 
-This package provides [launch/tps_astar_planner.launch.py](launch/tps_astar_planner.launch.py):
+### Template ROS 2 launch file
 
-    ros2 launch tps_astar_planner tps_astar_planner.launch.py
+```bash
+ros2 launch mrpt_tps_astar_planner tps_astar_planner.launch.py \
+    ptg_ini:=/path/to/ptgs.ini \
+    planner_parameters:=/path/to/planner-params.yaml \
+    global_costmap_parameters:=/path/to/costmap-obstacles.yaml \
+    prefer_waypoints_parameters:=/path/to/costmap-prefer-waypoints.yaml \
+    topic_obstacles_gridmap_sub:=/map \
+    topic_static_maps:=/map
+```
 
-which can be used in user projects to launch the planner, by setting these [launch arguments](https://docs.ros.org/en/rolling/Tutorials/Intermediate/Launch/Using-Substitutions.html):
-
-* ``XXX``: XXX
-
-
+All parameters have defaults in the launch file; only the config-file paths
+are typically required to be overridden for a real deployment.

--- a/mrpt_tps_astar_planner/launch/tps_astar_planner.launch.py
+++ b/mrpt_tps_astar_planner/launch/tps_astar_planner.launch.py
@@ -88,12 +88,12 @@ def generate_launch_description():
         description='The distance [m] to add as a margin all around the computed problem world bounding box')
 
     problem_world_bbox_ignore_obstacles_arg = DeclareLaunchArgument(
-        'problem_world_bbox_ignore_obstacles', default_value='False',
-        description='If True, the bounding box of obstacles is ignored while computing the problem world bounding box')
+        'problem_world_bbox_ignore_obstacles', default_value='false',
+        description='If true, the bounding box of obstacles is ignored while computing the problem world bounding box')
 
     astar_skip_refine_arg = DeclareLaunchArgument(
-        'astar_skip_refine', default_value='False',
-        description='If True, the refine stage after A* will be skipped')
+        'astar_skip_refine', default_value='false',
+        description='If true, the refine stage after A* will be skipped')
 
     # Node configuration
     tps_astar_nav_node = Node(

--- a/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
+++ b/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
@@ -114,6 +114,7 @@ class TPS_Astar_Planner_Node : public rclcpp::Node
 	rclcpp::Publisher<mrpt_msgs::msg::WaypointSequence>::SharedPtr pub_wp_seq_;
 	rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr pub_wp_path_seq_;
 	std::vector<rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr> pub_costmaps_;
+	std::mutex pub_costmaps_cs_;
 
 	// tf2 buffer and listener
 	std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
@@ -442,7 +443,7 @@ void TPS_Astar_Planner_Node::read_parameters()
 
 	this->declare_parameter<std::string>("topic_wp_seq_pub", "/waypoints");
 	this->get_parameter("topic_wp_seq_pub", topic_wp_seq_pub_);
-	RCLCPP_INFO(this->get_logger(), "topic_wp_seq_pub%s", topic_wp_seq_pub_.c_str());
+	RCLCPP_INFO(this->get_logger(), "topic_wp_seq_pub: %s", topic_wp_seq_pub_.c_str());
 
 	this->declare_parameter<std::string>("ptg_ini", ptg_ini_file_);
 	this->get_parameter("ptg_ini", ptg_ini_file_);
@@ -556,7 +557,13 @@ void TPS_Astar_Planner_Node::callback_goal(const geometry_msgs::msg::PoseStamped
 		mrpt::poses::CPose3D robot_pose;
 		const bool robot_pose_ok = wait_for_transform(robot_pose, frame_id_robot_, frame_id_map_);
 
-		ASSERT_(robot_pose_ok);
+		if (!robot_pose_ok)
+		{
+			RCLCPP_ERROR(
+				this->get_logger(),
+				"callback_goal: could not get robot pose from TF, ignoring goal.");
+			return;
+		}
 
 		/// Navigation start position
 		mrpt::math::TPose2D start_pose;
@@ -648,7 +655,8 @@ void TPS_Astar_Planner_Node::init_3d_debug()
 
 	for (const auto& e : gridmaps_) scene->insert(e.grid->getVisualization());
 
-	for (const auto& e : obstacle_points_) scene->insert(e.obstacle_points->getVisualization());
+	for (const auto& e : obstacle_points_)
+		if (e.obstacle_points) scene->insert(e.obstacle_points->getVisualization());
 
 	lck.unlock();
 
@@ -703,6 +711,13 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 	// gridmaps:
 	for (const auto& e : gridmaps_)
 	{
+		if (!e.grid_obstacles)
+		{
+			RCLCPP_WARN_THROTTLE(
+				get_logger(), *get_clock(), 5000,
+				"do_path_plan: gridmap not yet received, skipping.");
+			continue;
+		}
 		auto obs = mpp::ObstacleSource::FromStaticPointcloud(e.grid_obstacles);
 		pi.obstacles.emplace_back(obs);
 
@@ -719,6 +734,13 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 	// points:
 	for (const auto& e : obstacle_points_)
 	{
+		if (!e.obstacle_points)
+		{
+			RCLCPP_WARN_THROTTLE(
+				get_logger(), *get_clock(), 5000,
+				"do_path_plan: obstacle point cloud not yet received, skipping.");
+			continue;
+		}
 		auto obs = mpp::ObstacleSource::FromStaticPointcloud(e.obstacle_points);
 		pi.obstacles.emplace_back(obs);
 
@@ -788,24 +810,27 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 
 	// Publish costmaps:
 #if MRPT_VERSION >= 0x020e03  // >=v2.14.3
-	pub_costmaps_.resize(planner_->costEvaluators_.size());
-	for (size_t i = 0; i < planner_->costEvaluators_.size(); i++)
 	{
-		if (!pub_costmaps_[i])
+		auto lckPub = mrpt::lockHelper(pub_costmaps_cs_);
+		pub_costmaps_.resize(planner_->costEvaluators_.size());
+		for (size_t i = 0; i < planner_->costEvaluators_.size(); i++)
 		{
-			// See: REP-2003: https://ros.org/reps/rep-2003.html
-			const auto mapQoS = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
-			pub_costmaps_[i] = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
-				topic_costmaps_pub_ + mrpt::format("_%zu", i), mapQoS);
-		}
-		const auto& cm = planner_->costEvaluators_.at(i);
-		auto grid = cm->get_visualization_as_grid();
-		nav_msgs::msg::OccupancyGrid costMapMsg;
-		mrpt::ros2bridge::toROS(*grid, costMapMsg, true /*as costmap*/);
-		costMapMsg.header.frame_id = frame_id_map_;
-		costMapMsg.header.stamp = this->now();
+			if (!pub_costmaps_[i])
+			{
+				// See: REP-2003: https://ros.org/reps/rep-2003.html
+				const auto mapQoS = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
+				pub_costmaps_[i] = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+					topic_costmaps_pub_ + mrpt::format("_%zu", i), mapQoS);
+			}
+			const auto& cm = planner_->costEvaluators_.at(i);
+			auto grid = cm->get_visualization_as_grid();
+			nav_msgs::msg::OccupancyGrid costMapMsg;
+			mrpt::ros2bridge::toROS(*grid, costMapMsg, true /*as costmap*/);
+			costMapMsg.header.frame_id = frame_id_map_;
+			costMapMsg.header.stamp = this->now();
 
-		pub_costmaps_[i]->publish(costMapMsg);
+			pub_costmaps_[i]->publish(costMapMsg);
+		}
 	}
 #endif
 
@@ -823,6 +848,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 	// Show plan in a GUI for debugging
 	if (gui_mrpt_)
 	{
+		init_3d_debug();
 		mpp::VisualizationOptions vizOpts;
 
 		vizOpts.renderOptions.highlight_path_to_node_id = plan.bestNodeId;
@@ -898,7 +924,14 @@ void TPS_Astar_Planner_Node::srv_make_plan_to(
 		mrpt::poses::CPose3D robot_pose;
 		const bool robot_pose_ok = wait_for_transform(robot_pose, frame_id_robot_, frame_id_map_);
 
-		ASSERT_(robot_pose_ok);
+		if (!robot_pose_ok)
+		{
+			RCLCPP_ERROR(
+				this->get_logger(),
+				"srv_make_plan_to: could not get robot pose from TF, returning invalid plan.");
+			resp->valid_path_found = false;
+			return;
+		}
 
 		const auto start_pose = mrpt::poses::CPose2D(robot_pose).asTPose();
 
@@ -932,7 +965,7 @@ void TPS_Astar_Planner_Node::srv_make_plan_from_to(
 	}
 	catch (const std::exception& e)
 	{
-		RCLCPP_ERROR(this->get_logger(), "Exception in srv_make_plan_to: %s", e.what());
+		RCLCPP_ERROR(this->get_logger(), "Exception in srv_make_plan_from_to: %s", e.what());
 	}
 }
 

--- a/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
+++ b/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
@@ -71,6 +71,16 @@
 
 // version:
 #include <mrpt/version.h>
+#include <rclcpp/version.h>
+
+// create_service() QoS parameter type changed between ROS 2 distros:
+//   Humble (rclcpp 16.x) : const rmw_qos_profile_t&
+//   Iron+  (rclcpp 21+)  : const rclcpp::QoS&
+#if RCLCPP_VERSION_MAJOR >= 21
+#define MRPT_ROS2_SRV_QOS rclcpp::QoS(rclcpp::ServicesQoS())
+#else
+#define MRPT_ROS2_SRV_QOS rmw_qos_profile_services_default
+#endif
 
 const char* NODE_NAME = "mrpt_tps_astar_planner_node";
 
@@ -383,7 +393,7 @@ TPS_Astar_Planner_Node::TPS_Astar_Planner_Node() : rclcpp::Node(NODE_NAME)
 			const mrpt_nav_interfaces::srv::MakePlanTo::Request::SharedPtr req,
 			mrpt_nav_interfaces::srv::MakePlanTo::Response::SharedPtr res)
 		{ srv_make_plan_to(req, res); },
-		rmw_qos_profile_services_default, srv_cbg_);
+		MRPT_ROS2_SRV_QOS, srv_cbg_);
 
 	srvMakePlanFromTo_ = this->create_service<mrpt_nav_interfaces::srv::MakePlanFromTo>(
 		this->get_fully_qualified_name() + "/make_plan_from_to"s,
@@ -391,7 +401,7 @@ TPS_Astar_Planner_Node::TPS_Astar_Planner_Node() : rclcpp::Node(NODE_NAME)
 			const mrpt_nav_interfaces::srv::MakePlanFromTo::Request::SharedPtr req,
 			mrpt_nav_interfaces::srv::MakePlanFromTo::Response::SharedPtr res)
 		{ srv_make_plan_from_to(req, res); },
-		rmw_qos_profile_services_default, srv_cbg_);
+		MRPT_ROS2_SRV_QOS, srv_cbg_);
 
 	// Init planner:
 	// --------------------------

--- a/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
+++ b/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
@@ -61,6 +61,7 @@
 #include <tf2/LinearMath/Matrix3x3.hpp>
 #include <tf2/LinearMath/Quaternion.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <thread>
 
 // for debugging
 #include <mrpt/gui/CDisplayWindow3D.h>
@@ -179,13 +180,16 @@ class TPS_Astar_Planner_Node : public rclcpp::Node
 	/// Pointer to MRPT 3D display window
 	mrpt::gui::CDisplayWindow3D::Ptr win_3d_;
 
-	/// Path planner algorithm
-	mpp::Planner::Ptr planner_;
+	/// Planner params loaded once at startup, reused to init per-call local planner instances
+	mrpt::containers::yaml planner_params_yaml_;
 
 	mpp::TrajectoriesAndRobotShape ptgs_;
 
 	/// Parameters for the cost evaluator
 	mpp::CostEvaluatorCostMap::Parameters costMapParams_;
+
+	/// Reentrant callback group so service calls can run concurrently
+	rclcpp::CallbackGroup::SharedPtr srv_cbg_;
 
    private:
 	/**
@@ -284,6 +288,13 @@ class TPS_Astar_Planner_Node : public rclcpp::Node
 	rclcpp::Service<mrpt_nav_interfaces::srv::MakePlanFromTo>::SharedPtr srvMakePlanFromTo_;
 
 	/**
+	 * @brief Returns the planner instance for the calling thread, initializing
+	 * it on first use. Each executor thread keeps its own instance so
+	 * concurrent service calls never share mutable planner state.
+	 */
+	mpp::Planner& get_thread_planner();
+
+	/**
 	 * @brief Debug method to visualize the planning
 	 */
 	void init_3d_debug();
@@ -362,19 +373,25 @@ TPS_Astar_Planner_Node::TPS_Astar_Planner_Node() : rclcpp::Node(NODE_NAME)
 
 	// Init services:
 	// --------------------------
+	// Reentrant group: allows multiple service calls to execute in parallel
+	// when combined with MultiThreadedExecutor.
+	srv_cbg_ = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+
 	srvMakePlanTo_ = this->create_service<mrpt_nav_interfaces::srv::MakePlanTo>(
 		this->get_fully_qualified_name() + "/make_plan_to"s,
 		[this](
 			const mrpt_nav_interfaces::srv::MakePlanTo::Request::SharedPtr req,
 			mrpt_nav_interfaces::srv::MakePlanTo::Response::SharedPtr res)
-		{ srv_make_plan_to(req, res); });
+		{ srv_make_plan_to(req, res); },
+		rmw_qos_profile_services_default, srv_cbg_);
 
 	srvMakePlanFromTo_ = this->create_service<mrpt_nav_interfaces::srv::MakePlanFromTo>(
 		this->get_fully_qualified_name() + "/make_plan_from_to"s,
 		[this](
 			const mrpt_nav_interfaces::srv::MakePlanFromTo::Request::SharedPtr req,
 			mrpt_nav_interfaces::srv::MakePlanFromTo::Response::SharedPtr res)
-		{ srv_make_plan_from_to(req, res); });
+		{ srv_make_plan_from_to(req, res); },
+		rmw_qos_profile_services_default, srv_cbg_);
 
 	// Init planner:
 	// --------------------------
@@ -526,15 +543,15 @@ void TPS_Astar_Planner_Node::read_parameters()
 
 void TPS_Astar_Planner_Node::initialize_planner()
 {
-	planner_ = mpp::TPS_Astar::Create();
+	planner_params_yaml_ = mrpt::containers::yaml::FromFile(planner_params_file_);
 
-	// Enable time profiler:
-	planner_->profiler_().enable(true);
-
-	const auto c = mrpt::containers::yaml::FromFile(planner_params_file_);
-	planner_->params_from_yaml(c);
-	RCLCPP_INFO_STREAM(
-		this->get_logger(), "Loaded these planner params:" << planner_->params_as_yaml());
+	// Log loaded params using a temporary instance (not kept as shared state):
+	{
+		auto tmp = mpp::TPS_Astar::Create();
+		tmp->params_from_yaml(planner_params_yaml_);
+		RCLCPP_INFO_STREAM(
+			this->get_logger(), "Loaded these planner params:" << tmp->params_as_yaml());
+	}
 
 	mrpt::config::CConfigFile cfg(ptg_ini_file_);
 	RCLCPP_INFO_STREAM(this->get_logger(), "Initializing PTGs...");
@@ -545,6 +562,23 @@ void TPS_Astar_Planner_Node::initialize_planner()
 
 	costMapParams_ = mpp::CostEvaluatorCostMap::Parameters::FromYAML(
 		mrpt::containers::yaml::FromFile(costmap_params_file_));
+}
+
+mpp::Planner& TPS_Astar_Planner_Node::get_thread_planner()
+{
+	// One planner instance per OS thread, initialized lazily on first call.
+	// With MultiThreadedExecutor the thread pool is fixed after spin() starts,
+	// so each thread pays the init cost exactly once.
+	thread_local mpp::Planner::Ptr tl_planner;
+	if (!tl_planner)
+	{
+		tl_planner = mpp::TPS_Astar::Create();
+		tl_planner->profiler_().enable(true);
+		tl_planner->params_from_yaml(planner_params_yaml_);
+		RCLCPP_INFO_STREAM(
+			get_logger(), "Initialized planner for thread " << std::this_thread::get_id());
+	}
+	return *tl_planner;
 }
 
 void TPS_Astar_Planner_Node::callback_goal(const geometry_msgs::msg::PoseStamped& _goal)
@@ -700,11 +734,14 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 	bbox.updateWithPoint(mrpt::math::TPoint3D(start.translation()));
 	bbox.updateWithPoint(mrpt::math::TPoint3D(goal.translation()));
 
+	// Reuse the thread-local planner (initialized once per thread):
+	auto& local_planner = get_thread_planner();
+	local_planner.costEvaluators_.clear();
+
 	// Create obstacle sources, and find out bounding box:
 	// --------------------------------------------------------------
 	auto lckObs = mrpt::lockHelper(obstacles_cs_);
 
-	planner_->costEvaluators_.clear();
 	pi.obstacles.clear();
 
 	size_t obstacleSources = 0, totalObstaclePoints = 0;
@@ -729,7 +766,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 
 		auto costmap = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
 			*e.grid_obstacles, costMapParams_, pi.stateStart.pose);
-		planner_->costEvaluators_.push_back(costmap);
+		local_planner.costEvaluators_.push_back(costmap);
 	}
 	// points:
 	for (const auto& e : obstacle_points_)
@@ -755,7 +792,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 
 		auto costmap = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
 			*e.obstacle_points, costMapParams_, pi.stateStart.pose);
-		planner_->costEvaluators_.push_back(costmap);
+		local_planner.costEvaluators_.push_back(costmap);
 	}
 
 	lckObs.unlock();
@@ -784,7 +821,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 											<< "-" << pi.worldBboxMax.asString());
 
 	// Insert custom progress callback:
-	planner_->progressCallback_ = [this](const mpp::ProgressCallbackData& pcd)
+	local_planner.progressCallback_ = [this](const mpp::ProgressCallbackData& pcd)
 	{
 		RCLCPP_INFO_STREAM(
 			this->get_logger(),
@@ -793,7 +830,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 													 << " bestPathLength: " << pcd.bestPath.size());
 	};
 
-	const mpp::PlannerOutput plan = planner_->plan(pi);
+	const mpp::PlannerOutput plan = local_planner.plan(pi);
 
 	RCLCPP_INFO_STREAM(
 		this->get_logger(), "Done.\n"
@@ -812,8 +849,8 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 #if MRPT_VERSION >= 0x020e03  // >=v2.14.3
 	{
 		auto lckPub = mrpt::lockHelper(pub_costmaps_cs_);
-		pub_costmaps_.resize(planner_->costEvaluators_.size());
-		for (size_t i = 0; i < planner_->costEvaluators_.size(); i++)
+		pub_costmaps_.resize(local_planner.costEvaluators_.size());
+		for (size_t i = 0; i < local_planner.costEvaluators_.size(); i++)
 		{
 			if (!pub_costmaps_[i])
 			{
@@ -822,7 +859,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 				pub_costmaps_[i] = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
 					topic_costmaps_pub_ + mrpt::format("_%zu", i), mapQoS);
 			}
-			const auto& cm = planner_->costEvaluators_.at(i);
+			const auto& cm = local_planner.costEvaluators_.at(i);
 			auto grid = cm->get_visualization_as_grid();
 			nav_msgs::msg::OccupancyGrid costMapMsg;
 			mrpt::ros2bridge::toROS(*grid, costMapMsg, true /*as costmap*/);
@@ -833,8 +870,6 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 		}
 	}
 #endif
-
-	// TODO(jlbc) Why? Remove? if (!plan.success) planner_->costEvaluators_.clear();
 
 	// backtrack:
 	auto [plannedPath, pathEdges] = plan.motionTree.backtrack_path(*plan.bestNodeId);
@@ -856,7 +891,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 		vizOpts.renderOptions.width_normal_edge = 0;  // hide all edges except best path
 		vizOpts.gui_modal = false;	// leave GUI open in a background thread
 
-		mpp::viz_nav_plan(plan, vizOpts, planner_->costEvaluators_);
+		mpp::viz_nav_plan(plan, vizOpts, local_planner.costEvaluators_);
 	}
 
 	// Interpolate so we have many waypoints:
@@ -974,7 +1009,9 @@ int main(int argc, char** argv)
 {
 	rclcpp::init(argc, argv);
 	auto node = std::make_shared<TPS_Astar_Planner_Node>();
-	rclcpp::spin(node);
+	rclcpp::executors::MultiThreadedExecutor exec;
+	exec.add_node(node);
+	exec.spin();
 	rclcpp::shutdown();
 	return 0;
 }

--- a/mrpt_tutorials/launch/demo_astar_planner_gridmap.launch.py
+++ b/mrpt_tutorials/launch/demo_astar_planner_gridmap.launch.py
@@ -76,7 +76,7 @@ def generate_launch_description():
             get_package_share_directory('mrpt_pointcloud_pipeline'), 'launch',
             'pointcloud_pipeline.launch.py')]),
         launch_arguments={
-            'use_composable': 'False',
+            'use_composable': 'false',
             'log_level': 'INFO',
             'scan_topic_name': '/laser1, /laser2',
             'points_topic_name': '/lidar1_points',

--- a/mrpt_tutorials/launch/demo_pointcloud_pipeline_mvsim.launch.py
+++ b/mrpt_tutorials/launch/demo_pointcloud_pipeline_mvsim.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
             get_package_share_directory('mrpt_pointcloud_pipeline'), 'launch',
             'pointcloud_pipeline.launch.py')]),
         launch_arguments={
-            'use_composable': 'False',
+            'use_composable': 'false',
             'log_level': 'INFO',
             'scan_topic_name': '/laser1, /laser2',
             'points_topic_name': '/camera1_points',

--- a/mrpt_tutorials/launch/demo_reactive_nav_mvsim.launch.py
+++ b/mrpt_tutorials/launch/demo_reactive_nav_mvsim.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
             get_package_share_directory('mrpt_pointcloud_pipeline'), 'launch',
             'pointcloud_pipeline.launch.py')]),
         launch_arguments={
-            'use_composable': 'False',
+            'use_composable': 'false',
             'log_level': 'INFO',
             'scan_topic_name': '/scanner1',
             'points_topic_name': '/lidar1_points',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit `use_composable` launch-argument control and updated container description across launches; planner now handles concurrent service requests via multi-threaded execution and per-thread planner instances.

* **Bug Fixes**
  * Graceful TF error handling, thread-safe costmap publishing, and quieter/skipping behavior for missing or null obstacle inputs.

* **Documentation**
  * Expanded README with configuration details, topics/services, and usage examples.

* **Chores**
  * Include/formatting reorders and normalization of boolean launch-defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->