### PR TITLE
bump min req cmake version to 3.22

### DIFF
--- a/mrpt_map_server/CMakeLists.txt
+++ b/mrpt_map_server/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_map_server)
 
 # find dependencies

--- a/mrpt_msgs_bridge/CMakeLists.txt
+++ b/mrpt_msgs_bridge/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_msgs_bridge)
 
 # find dependencies

--- a/mrpt_nav_interfaces/CMakeLists.txt
+++ b/mrpt_nav_interfaces/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 project(mrpt_nav_interfaces)
 

--- a/mrpt_navigation/CMakeLists.txt
+++ b/mrpt_navigation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 
 project(mrpt_navigation)
 

--- a/mrpt_pf_localization/CMakeLists.txt
+++ b/mrpt_pf_localization/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_pf_localization)
 
 # find dependencies

--- a/mrpt_pointcloud_pipeline/CMakeLists.txt
+++ b/mrpt_pointcloud_pipeline/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_pointcloud_pipeline)
 
 # find dependencies

--- a/mrpt_reactivenav2d/CMakeLists.txt
+++ b/mrpt_reactivenav2d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_reactivenav2d)
 
 # find dependencies

--- a/mrpt_tps_astar_planner/CMakeLists.txt
+++ b/mrpt_tps_astar_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_tps_astar_planner)
 
 # find dependencies

--- a/mrpt_tutorials/CMakeLists.txt
+++ b/mrpt_tutorials/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_tutorials)
 
 # find dependencies


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum build system version requirement from 3.5/3.8 to 3.22–3.31 across all packages, ensuring compatibility with modern development environments, particularly Ubuntu 22.04+. No changes to functionality or build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->