### PR TITLE
build: enable ccache in all packages when available

### DIFF
--- a/mrpt_map_server/CMakeLists.txt
+++ b/mrpt_map_server/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_map_server)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/mrpt_msgs_bridge/CMakeLists.txt
+++ b/mrpt_msgs_bridge/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_msgs_bridge)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 

--- a/mrpt_nav_interfaces/CMakeLists.txt
+++ b/mrpt_nav_interfaces/CMakeLists.txt
@@ -4,6 +4,12 @@ cmake_minimum_required(VERSION 3.10)
 
 project(mrpt_nav_interfaces)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)

--- a/mrpt_pf_localization/CMakeLists.txt
+++ b/mrpt_pf_localization/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_pf_localization)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 

--- a/mrpt_pointcloud_pipeline/CMakeLists.txt
+++ b/mrpt_pointcloud_pipeline/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_pointcloud_pipeline)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/mrpt_reactivenav2d/CMakeLists.txt
+++ b/mrpt_reactivenav2d/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_reactivenav2d)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/mrpt_tps_astar_planner/CMakeLists.txt
+++ b/mrpt_tps_astar_planner/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.22...3.31)  # Ubuntu 22.04+
 project(mrpt_tps_astar_planner)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+  set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)


### PR DESCRIPTION
## Summary
- Added `find_program(CCACHE_PROGRAM ccache)` + `CMAKE_C/CXX_COMPILER_LAUNCHER` to all 7 packages that compile C/C++ code: `mrpt_map_server`, `mrpt_msgs_bridge`, `mrpt_nav_interfaces`, `mrpt_pf_localization`, `mrpt_pointcloud_pipeline`, `mrpt_reactivenav2d`, `mrpt_tps_astar_planner`.
- The block is a no-op when ccache is not installed, so it is fully backwards-compatible.
- Packages without compiled targets (`mrpt_navigation`, `mrpt_tutorials`) are left untouched.

## Test plan
- [ ] CI builds green (the ccache block is transparent when ccache is absent, which is the case on CI runners)
- [ ] Local rebuild after `touch` of a single file is noticeably faster when ccache is installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build configurations now automatically use compiler caching when available, speeding up repeated C and C++ builds.
  * This improvement applies across multiple packages, with no change to runtime behavior or installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->