### PR TITLE
Add publish_tf parameter

### DIFF
--- a/mrpt_pf_localization/include/mrpt_pf_localization_node.h
+++ b/mrpt_pf_localization/include/mrpt_pf_localization_node.h
@@ -79,6 +79,9 @@ class PFLocalizationNode : public rclcpp::Node
 		std::string pub_topic_particles = "/particlecloud";
 		std::string pub_topic_pose = "/pf_pose";
 
+		/// If false, skip publishing map→odom (e.g. robot_localization EKF owns that TF)
+		bool publish_tf = true;
+
 		/// Comma "," separated list of topics to subscribe for LaserScan msgs
 		std::string topic_sensors_2d_scan;
 

--- a/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
@@ -187,7 +187,10 @@ PFLocalizationNode::PFLocalizationNode(const rclcpp::NodeOptions& options)
 		std::chrono::microseconds(mrpt::round(0.5 * 1.0e6 * nodeParams_.transform_tolerance)),
 		[this]()
 		{
-			if (nodeParams_.publish_tf) this->publishTF();
+			if (nodeParams_.publish_tf)
+			{
+				this->publishTF();
+			}
 			// publishParticles() && publishPose() are done inside loop()
 		});
 }
@@ -609,7 +612,8 @@ void PFLocalizationNode::publishParticlesAndStampedPose()
  */
 void PFLocalizationNode::update_tf_pub_data()
 {
-	if (!nodeParams_.publish_tf) {
+	if (!nodeParams_.publish_tf)
+	{
 		return;
 	}
 	std::string base_frame_id = nodeParams_.base_link_frame_id;

--- a/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
@@ -187,7 +187,7 @@ PFLocalizationNode::PFLocalizationNode(const rclcpp::NodeOptions& options)
 		std::chrono::microseconds(mrpt::round(0.5 * 1.0e6 * nodeParams_.transform_tolerance)),
 		[this]()
 		{
-			this->publishTF();
+			if (nodeParams_.publish_tf) this->publishTF();
 			// publishParticles() && publishPose() are done inside loop()
 		});
 }
@@ -609,6 +609,9 @@ void PFLocalizationNode::publishParticlesAndStampedPose()
  */
 void PFLocalizationNode::update_tf_pub_data()
 {
+	if (!nodeParams_.publish_tf) {
+		return;
+	}
 	std::string base_frame_id = nodeParams_.base_link_frame_id;
 	std::string odom_frame_id = nodeParams_.odom_frame_id;
 	std::string global_frame_id = nodeParams_.global_frame_id;
@@ -711,6 +714,7 @@ void PFLocalizationNode::NodeParameters::loadFrom(const mrpt::containers::yaml& 
 
 	MCP_LOAD_OPT(cfg, pub_topic_particles);
 	MCP_LOAD_OPT(cfg, pub_topic_pose);
+	MCP_LOAD_OPT(cfg, publish_tf);
 
 	MCP_LOAD_OPT(cfg, topic_sensors_2d_scan);
 	MCP_LOAD_OPT(cfg, topic_sensors_point_clouds);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `publish_tf` configuration option to control whether the `map→odom` transform is published.
  - When `publish_tf` is disabled (`false`), the node skips TF publication and does not refresh the cached data used for TF output.
- **Configuration**
  - Set `publish_tf` via the existing ROS/config YAML parameters.
  - Default: enabled (`publish_tf: true`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->