### PR TITLE
fix(tps_astar_planner): serialize planning to avoid concurrent PTG corruption

### DIFF
--- a/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
+++ b/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
@@ -191,6 +191,16 @@ class TPS_Astar_Planner_Node : public rclcpp::Node
 
 	mpp::TrajectoriesAndRobotShape ptgs_;
 
+	// ptgs_ holds shared_ptr<ptg_t> entries that are reused (not cloned) by
+	// every do_path_plan() call via pi.ptgs = ptgs_. The PTG implementations
+	// mutate internal scratch state while evaluating a plan, so with the
+	// reentrant callback group + MultiThreadedExecutor below, concurrent
+	// service calls can run plan() on the same PTG objects at once and
+	// corrupt each other's search. Serialize the actual planning call with
+	// this mutex instead of trying to make every PTG implementation
+	// thread-safe.
+	std::mutex planning_cs_;
+
 	/// Parameters for the cost evaluator
 	mpp::CostEvaluatorCostMap::Parameters costMapParams_;
 
@@ -809,7 +819,13 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 													 << " bestPathLength: " << pcd.bestPath.size());
 	};
 
-	const mpp::PlannerOutput plan = local_planner.plan(pi);
+	// See planning_cs_ comment: pi.ptgs shares PTG instances with any other
+	// concurrent do_path_plan() call, and PTG evaluation is not reentrant.
+	mpp::PlannerOutput plan;
+	{
+		auto lckPlan = mrpt::lockHelper(planning_cs_);
+		plan = local_planner.plan(pi);
+	}
 
 	RCLCPP_INFO_STREAM(
 		this->get_logger(), "Done.\n"


### PR DESCRIPTION
## Summary
- `mrpt_tps_astar_planner_node` registers its `MakePlanFromTo`/`MakePlanTo` services on a `Reentrant` callback group spun by a `MultiThreadedExecutor`, so multiple planning requests can execute `do_path_plan()` concurrently on different threads.
- Each thread gets its own thread-local `Planner` via `get_thread_planner()`, but `pi.ptgs = ptgs_` copies a `std::vector<std::shared_ptr<ptg_t>>` whose PTG instances are shared (not cloned) across every call. PTG trajectory evaluation mutates internal scratch state, so two concurrent `plan()` calls touching the same PTG objects race.
- Observed in the wild: a client fired several byte-identical `MakePlanFromTo` requests (same start/goal) within ~0.2ms of each other; 3 came back "no path found" (0 waypoints, invalid) and 1 succeeded — impossible for a deterministic planner given identical inputs, and consistent with a data race in PTG evaluation.

## Fix
Add a dedicated `planning_cs_` mutex and serialize only the actual `local_planner.plan(pi)` call, leaving obstacle/costmap handling and the reentrant group's other benefits untouched. This is a minimal, surgical fix rather than auditing every PTG implementation for thread-safety.

## Test plan
- [x] `colcon build --packages-select mrpt_tps_astar_planner` succeeds
- [ ] Maintainers: confirm no regression in planning throughput under normal (non-concurrent) load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planning reliability under concurrent requests by preventing overlapping planning operations.
  * Reduced the risk of inconsistent or corrupted path-planning results when multiple calls arrive at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->