### PR TITLE
feat(tps_astar_planner): pass robot shape to the clearance costmap

### DIFF
--- a/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
+++ b/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
@@ -81,6 +81,25 @@
 #define MRPT_ROS2_SRV_QOS rmw_qos_profile_services_default
 #endif
 
+namespace
+{
+// Build the obstacle clearance costmap. The robot shape is forwarded to make the
+// costmap footprint-aware when the linked mpp exposes the newer overload
+// (feature macro from CostEvaluatorCostMap.h); against older mpp it falls back
+// to the origin-only signature, so this node keeps building either way.
+mpp::CostEvaluatorCostMap::Ptr makeCostmapEvaluator(
+	const mrpt::maps::CPointsMap& obstacles, const mpp::CostEvaluatorCostMap::Parameters& params,
+	const mrpt::math::TPose2D& startPose, [[maybe_unused]] const mpp::RobotShape& robotShape)
+{
+#if defined(MPP_COSTEVALUATORCOSTMAP_HAS_ROBOT_SHAPE)
+	return mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
+		obstacles, params, startPose, robotShape);
+#else
+	return mpp::CostEvaluatorCostMap::FromStaticPointObstacles(obstacles, params, startPose);
+#endif
+}
+}  // namespace
+
 const char* NODE_NAME = "mrpt_tps_astar_planner_node";
 
 /**
@@ -753,8 +772,8 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 		obstacleSources++;
 		totalObstaclePoints += e.grid_obstacles->size();
 
-		auto costmap = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
-			*e.grid_obstacles, costMapParams_, pi.stateStart.pose);
+		auto costmap = makeCostmapEvaluator(
+			*e.grid_obstacles, costMapParams_, pi.stateStart.pose, ptgs_.robotShape);
 		local_planner.costEvaluators_.push_back(costmap);
 	}
 	// points:
@@ -779,8 +798,8 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 		obstacleSources++;
 		totalObstaclePoints += e.obstacle_points->size();
 
-		auto costmap = mpp::CostEvaluatorCostMap::FromStaticPointObstacles(
-			*e.obstacle_points, costMapParams_, pi.stateStart.pose);
+		auto costmap = makeCostmapEvaluator(
+			*e.obstacle_points, costMapParams_, pi.stateStart.pose, ptgs_.robotShape);
 		local_planner.costEvaluators_.push_back(costmap);
 	}
 


### PR DESCRIPTION
Forwards `ptgs_.robotShape` to `CostEvaluatorCostMap::FromStaticPointObstacles` at both obstacle-source call sites in the planner node, so the clearance costmap is **footprint-aware**: the cost reflects the robot footprint's proximity to obstacles instead of just the `base_link` origin's. For long/asymmetric robots this makes `preferredClearanceDistance` correspond to real footprint clearance (the origin can sit a full clearance-distance from an obstacle while the footprint grazes it).

Depends on the footprint-aware `CostEvaluatorCostMap` overload from **MRPT/mrpt_path_planning#33**. The new argument is defaulted (`std::monostate`) there, so this change is a safe no-op until that PR lands.

Measured on a benchmark (long ~1.75 m footprint): with footprint-awareness, an intuitive `preferredClearanceDistance=0.75, maxCost=2.0` yields ~0.31–0.62 m real footprint clearance on tight cases, matching what origin-only sampling needed `1.5 / 4.0` to reach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static obstacle cost evaluation by incorporating the robot’s shape when generating planning cost maps.
  * Enhanced path planning consistency for static obstacles from both grid-based and point-cloud sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->