### PR TITLE
feat(trajectory_follower): expose arrival_radius param

### DIFF
--- a/mrpt_trajectory_follower/configs/params/follower-params.yaml
+++ b/mrpt_trajectory_follower/configs/params/follower-params.yaml
@@ -16,6 +16,7 @@ lookahead_time: 1.0        # [s]
 goal_dist_tol: 0.15        # [m]
 goal_ang_tol: 12.0         # [deg]
 max_cross_track: 1.0       # [m] -> OffPathExceeded
+arrival_radius: 0.3        # [m] settle-and-hold radius at the goal (anti-runaway)
 
 # --- Loop timing ---
 control_period: 0.05       # [s] (20 Hz)


### PR DESCRIPTION
Adds the `arrival_radius` parameter to `mrpt_trajectory_follower`'s
`follower-params.yaml`, matching the new `mpp::TrajectoryFollower::Parameters::arrival_radius`
in MRPT/mrpt_path_planning#35.

`arrival_radius` is the settle-and-hold radius at the goal: once the robot is
within it and has passed its closest approach, the follower latches a stop, so a
goal pose it cannot perfectly seat never becomes a runaway into nearby obstacles.

Depends on MRPT/mrpt_path_planning#35 (the library param).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an arrival radius setting to control how close the follower must be to a goal before entering arrival and hold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->