### PR TITLE
trajectory_follower: only publish cmd_vel while actively driving

### DIFF
--- a/mrpt_trajectory_follower/src/mrpt_trajectory_follower_node.cpp
+++ b/mrpt_trajectory_follower/src/mrpt_trajectory_follower_node.cpp
@@ -28,6 +28,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <atomic>
 #include <chrono>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -116,6 +117,14 @@ class TrajectoryFollowerNode : public rclcpp::Node, public mpp::TrajectoryVehicl
 	std::mutex wd_cs_;
 	rclcpp::Time last_cmd_time_;
 	std::chrono::milliseconds wd_timeout_{0};
+
+	// True only while actively emitting a driving command (status Running). Used
+	// so the node never spams zero cmd_vel when idle or after ReachedGoal/Blocked
+	// -- otherwise a downstream twist_mux would treat this node as a permanently
+	// active input and fight other cmd_vel sources (e.g. teleop). We publish one
+	// clean zero on the transition to a stopped state, then stay silent until a
+	// new reference path arrives.
+	std::atomic<bool> actively_driving_{false};
 
 	// Params:
 	std::string frame_id_map_ = "map";
@@ -356,6 +365,13 @@ void TrajectoryFollowerNode::start_watchdog(std::chrono::milliseconds timeout)
 		std::chrono::milliseconds(checkPeriod),
 		[this]()
 		{
+			// Only guard an actively driving loop: when idle or already stopped,
+			// staying silent lets a downstream mux time this input out instead of
+			// us fighting other cmd_vel sources with a stream of zeros.
+			if (!actively_driving_.load())
+			{
+				return;
+			}
 			auto lck = std::lock_guard(wd_cs_);
 			if (wd_timeout_.count() <= 0)
 			{
@@ -544,7 +560,11 @@ void TrajectoryFollowerNode::control_tick()
 	const auto loc = get_localization();
 	if (!loc.valid)
 	{
-		stop(mpp::StopKind::EMERGENCY);
+		// Emit a single stop only if we were driving; then stay silent.
+		if (actively_driving_.exchange(false))
+		{
+			stop(mpp::StopKind::EMERGENCY);
+		}
 		return;
 	}
 	const auto odo = get_odometry();
@@ -559,9 +579,16 @@ void TrajectoryFollowerNode::control_tick()
 	{
 		case mpp::FollowerStatus::ReachedGoal:
 		case mpp::FollowerStatus::Blocked:
-			stop(mpp::StopKind::REGULAR);
+			// Publish one clean zero on the transition to stopped, then stay
+			// silent (don't re-publish every tick) so a downstream mux can time
+			// this input out. Status keeps being published below regardless.
+			if (actively_driving_.exchange(false))
+			{
+				stop(mpp::StopKind::REGULAR);
+			}
 			break;
 		default:
+			actively_driving_ = true;
 			follow(out.command);
 			break;
 	}


### PR DESCRIPTION
The node published zero cmd_vel continuously when idle or after ReachedGoal/Blocked (watchdog + per-tick stop()). Feeding a twist_mux, that kept the follower's input permanently active, so the mux output fought other cmd_vel sources (e.g. teleop). Track an actively_driving_ flag: emit one clean zero on the transition to stopped, then stay silent (status keeps publishing); gate the watchdog on it too. When idle (no trajectory) the node stays silent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated stop commands when the robot is already stopped.
  * Improved emergency-stop handling when localization becomes invalid.
  * Updated watchdog behavior to intervene only while the robot is actively driving.
  * Ensured stop commands are sent once when the robot reaches its goal or becomes blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->