### PR TITLE
fix(tps_astar_planner): properly SFINAE-guard windowTitle and ptgStepIndex

### DIFF
--- a/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
+++ b/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
@@ -102,9 +102,12 @@ mpp::CostEvaluatorCostMap::Ptr makeCostmapEvaluator(
 #endif
 }
 
-// mpp::VisualizationOptions::windowTitle is only present in newer mpp
-// releases; detect it at compile time so this node keeps building against
-// older, already-released binary packages that lack the field.
+// mpp::VisualizationOptions::windowTitle and MoveEdgeSE2_TPS::ptgStepIndex are
+// only present in newer mpp releases; detect them at compile time so this node
+// keeps building against older, already-released binary packages that lack
+// those fields. The detection+call must live in a template so `if constexpr`
+// actually discards the invalid branch instead of still requiring it to be
+// well-formed (which is what a plain, non-template function would do).
 template <typename T, typename = void>
 struct HasWindowTitle : std::false_type
 {
@@ -115,15 +118,48 @@ struct HasWindowTitle<T, std::void_t<decltype(std::declval<T&>().windowTitle)>> 
 {
 };
 
-void setWindowTitle(mpp::VisualizationOptions& vizOpts, const std::string& title)
+template <typename T>
+void setWindowTitle(T& vizOpts, const std::string& title)
 {
-	if constexpr (HasWindowTitle<mpp::VisualizationOptions>::value)
+	if constexpr (HasWindowTitle<T>::value)
 	{
 		vizOpts.windowTitle = title;
 	}
 	else
 	{
-		[[maybe_unused]] const auto& unused = title;
+		(void)vizOpts;
+		(void)title;
+	}
+}
+
+template <typename T, typename = void>
+struct HasPtgStepIndex : std::false_type
+{
+};
+
+template <typename T>
+struct HasPtgStepIndex<T, std::void_t<decltype(std::declval<T&>().ptgStepIndex)>> : std::true_type
+{
+};
+
+// Re-interpolate a solution edge at a finer resolution, just for GUI
+// rendering. No-op against older mpp releases lacking
+// MoveEdgeSE2_TPS::ptgStepIndex: the debug GUI then falls back to the
+// coarser interpolation already computed during the tree search.
+template <typename EdgeT, typename PtgsT>
+void densifyEdgeForGui(
+	EdgeT& edge, const PtgsT& ptgs, const mrpt::math::TPose2D& reconstrRelPose, size_t numSegments)
+{
+	if constexpr (HasPtgStepIndex<EdgeT>::value)
+	{
+		mpp::edge_interpolated_path(edge, ptgs, reconstrRelPose, edge.ptgStepIndex, numSegments);
+	}
+	else
+	{
+		(void)edge;
+		(void)ptgs;
+		(void)reconstrRelPose;
+		(void)numSegments;
 	}
 }
 }  // namespace
@@ -939,8 +975,7 @@ TPS_Astar_Planner_Node::PlanResult TPS_Astar_Planner_Node::do_path_plan(
 		{
 			if (!e) continue;
 			const auto reconstrRelPose = e->stateTo.pose - e->stateFrom.pose;
-			mpp::edge_interpolated_path(
-				*e, pi.ptgs, reconstrRelPose, e->ptgStepIndex, kGuiPathInterpSegments);
+			densifyEdgeForGui(*e, pi.ptgs, reconstrRelPose, kGuiPathInterpSegments);
 		}
 
 		mpp::VisualizationOptions vizOpts;


### PR DESCRIPTION
## Summary
- CI's \`CI Build colcon\` has been failing on `ros2` since commit 4b6fe39 because `mrpt_tps_astar_planner_node.cpp` uses `mpp::VisualizationOptions::windowTitle` and `mpp::MoveEdgeSE2_TPS::ptgStepIndex`, two fields only present in newer `mrpt_path_planning` sources. CI installs that dependency from the ROS binary repos (rosdep/apt), which don't have those fields yet, so the build fails with "has no member named ...".
- 4b6fe39 already attempted a fix via `if constexpr`, but it wrapped the field access in a plain (non-template) function. `if constexpr` only discards a branch when its well-formedness depends on a template parameter — in a non-template function the compiler still has to validate both branches, so the "fix" didn't actually fix anything.
- This PR moves the detection + field access into template functions so `if constexpr` genuinely discards the unavailable branch, and applies the same pattern to `ptgStepIndex` (used by the GUI-only path densification added in the same commit as `windowTitle`, with the same compatibility problem).

## Test plan
- [x] Local build against this machine's (newer) `mrpt_path_planning` succeeds unchanged.
- [x] Isolated compile test with stand-in "old API" (no `windowTitle`/`ptgStepIndex`) and "new API" (both present) types confirms the templated `if constexpr` pattern discards the invalid branch for the old-API type and compiles the field access for the new-API type.
- [ ] CI green on all 4 build matrix jobs (humble/jazzy × stable/testing).