### PR TITLE
Port to MRPT 3.x

### DIFF
--- a/mrpt_map_server/CMakeLists.txt
+++ b/mrpt_map_server/CMakeLists.txt
@@ -12,9 +12,9 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
-find_package(mrpt-maps REQUIRED)
-find_package(mrpt-ros2bridge REQUIRED)
-find_package(mrpt-topography REQUIRED)  # shipped by ROS pkg mrpt_libobs
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_libros_bridge REQUIRED)
+find_package(mrpt_topography REQUIRED)  # shipped by ROS pkg mrpt_libobs
 find_package(mp2p_icp_map REQUIRED)
 
 message(STATUS "MRPT_VERSION: ${MRPT_VERSION}")
@@ -54,13 +54,15 @@ target_include_directories(map_server_node
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+  # Ensure workspace mrpt_libros_bridge headers take priority over system ones:
+  ${mrpt_libros_bridge_INCLUDE_DIRS}
 )
 
 # Specify libraries to link a library or executable target against
 target_link_libraries(map_server_node PRIVATE
-  mrpt::maps
-  mrpt::ros2bridge
-  mrpt::topography
+  mrpt::mrpt_maps
+  mrpt_libros_bridge::mrpt_libros_bridge
+  mrpt::mrpt_topography
   mola::mp2p_icp_map
   rclcpp::rclcpp
   ${rclcpp_components_TARGETS}

--- a/mrpt_map_server/package.xml
+++ b/mrpt_map_server/package.xml
@@ -14,8 +14,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend version_gte="1.6.2">mp2p_icp</depend>
-  <depend>mrpt_libobs</depend>
-  <depend>mrpt_libmaps</depend>
+  <depend>mrpt_obs</depend>
+  <depend>mrpt_maps</depend>
   <depend>mrpt_libros_bridge</depend>
   <depend>mrpt_msgs</depend>
   <depend>mrpt_nav_interfaces</depend>

--- a/mrpt_msgs_bridge/CMakeLists.txt
+++ b/mrpt_msgs_bridge/CMakeLists.txt
@@ -14,10 +14,12 @@ if(marker_msgs_FOUND)
     set(MARKER_SRC src/marker_msgs.cpp)
 endif()
 
-find_package(mrpt-ros2bridge REQUIRED)
-find_package(mrpt-obs REQUIRED)
+find_package(mrpt_libros_bridge REQUIRED)
+# Ensure workspace mrpt_libros_bridge headers take priority over system ones:
+include_directories(BEFORE ${mrpt_libros_bridge_INCLUDE_DIRS})
+find_package(mrpt_obs REQUIRED)
 
-message(STATUS "MRPT_VERSION: ${mrpt-obs_VERSION}")
+message(STATUS "MRPT_VERSION: ${mrpt_obs_VERSION}")
 
 if(CMAKE_COMPILER_IS_GNUCXX)
   # High level of warnings.
@@ -68,8 +70,8 @@ install(DIRECTORY include/${PROJECT_NAME}
 
 # Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME} PRIVATE
-  mrpt::obs
-  mrpt::ros2bridge
+  mrpt::mrpt_obs
+  mrpt_libros_bridge::mrpt_libros_bridge
   rclcpp::rclcpp
   tf2::tf2
   ${mrpt_msgs_TARGETS}

--- a/mrpt_msgs_bridge/include/mrpt_msgs_bridge/network_of_poses.hpp
+++ b/mrpt_msgs_bridge/include/mrpt_msgs_bridge/network_of_poses.hpp
@@ -40,14 +40,6 @@ void toROS(
 	const mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph,
 	mrpt_msgs::msg::NetworkOfPoses& ros_graph);
 
-void toROS(
-	const mrpt::graphs::CNetworkOfPoses2DInf_NA& mrpt_graph,
-	mrpt_msgs::msg::NetworkOfPoses& ros_graph);
-
-void toROS(
-	const mrpt::graphs::CNetworkOfPoses3DInf_NA& mrpt_graph,
-	mrpt_msgs::msg::NetworkOfPoses& ros_graph);
-
 /**\} */
 
 /////////////////////////////////////////////////////////////////////////
@@ -71,14 +63,6 @@ void fromROS(
 void fromROS(
 	const mrpt_msgs::msg::NetworkOfPoses& ros_graph,
 	mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph);
-
-void fromROS(
-	const mrpt_msgs::msg::NetworkOfPoses& ros_graph,
-	mrpt::graphs::CNetworkOfPoses2DInf_NA& mrpt_graph);
-
-void fromROS(
-	const mrpt_msgs::msg::NetworkOfPoses& ros_graph,
-	mrpt::graphs::CNetworkOfPoses3DInf_NA& mrpt_graph);
 
 /**\} */
 

--- a/mrpt_msgs_bridge/package.xml
+++ b/mrpt_msgs_bridge/package.xml
@@ -18,7 +18,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>geometry_msgs</depend>
-  <depend>mrpt_libobs</depend>
+  <depend>mrpt_obs</depend>
   <depend>mrpt_libros_bridge</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>

--- a/mrpt_msgs_bridge/src/beacon.cpp
+++ b/mrpt_msgs_bridge/src/beacon.cpp
@@ -54,11 +54,8 @@ bool mrpt_msgs_bridge::fromROS(
 bool mrpt_msgs_bridge::toROS(
 	const CObservationBeaconRanges& _obj, mrpt_msgs::msg::ObservationRangeBeacon& _msg)
 {
-	mrpt::poses::CPose3D cpose_obj;
-
 	_msg.header.stamp = mrpt::ros2bridge::toROS(_obj.timestamp);
-	_obj.getSensorPose(cpose_obj);
-	_msg.sensor_pose_on_robot = mrpt::ros2bridge::toROS_Pose(cpose_obj);
+	_msg.sensor_pose_on_robot = mrpt::ros2bridge::toROS_Pose(_obj.getSensorPose());
 
 	_msg.sensor_std_range = _obj.stdError;
 	_msg.header.frame_id = _obj.sensorLabel;
@@ -83,8 +80,6 @@ bool mrpt_msgs_bridge::toROS(
 	geometry_msgs::msg::Pose& _pose)
 {
 	toROS(_obj, _msg);
-	mrpt::poses::CPose3D pose;
-	_obj.getSensorPose(pose);
-	_pose = mrpt::ros2bridge::toROS_Pose(pose);
+	_pose = mrpt::ros2bridge::toROS_Pose(_obj.getSensorPose());
 	return true;
 }

--- a/mrpt_msgs_bridge/src/network_of_poses.cpp
+++ b/mrpt_msgs_bridge/src/network_of_poses.cpp
@@ -91,86 +91,6 @@ void mrpt_msgs_bridge::toROS(
 	// conversion
 }
 
-void mrpt_msgs_bridge::toROS(
-	const mrpt::graphs::CNetworkOfPoses2DInf_NA& mrpt_graph,
-	mrpt_msgs::msg::NetworkOfPoses& ros_graph)
-{
-	MRPT_START
-
-	using namespace geometry_msgs::msg;
-	using namespace mrpt::math;
-	using namespace mrpt::graphs;
-	using namespace mrpt::poses;
-	using namespace std;
-
-	typedef
-		typename mrpt::graphs::CNetworkOfPoses2DInf_NA::global_poses_t::const_iterator poses_cit_t;
-
-	//// debugging print.
-	// for (poses_cit_t it = mrpt_graph.nodes.begin();
-	// it != mrpt_graph.nodes.end();
-	//++it) {
-	// cout << it->first << " | " << it->second << endl;
-	//}
-
-	const CNetworkOfPoses2DInf_NA::BASE::edges_map_t& constraints = mrpt_graph.BASE::edges;
-
-	// fill root node
-	ros_graph.root = mrpt_graph.root;
-
-	// fill nodeIDs, positions
-	for (poses_cit_t poses_cit = mrpt_graph.nodes.begin(); poses_cit != mrpt_graph.nodes.end();
-		 ++poses_cit)
-	{
-		mrpt_msgs::msg::NodeIDWithPose ros_node;
-
-		// nodeID
-		ros_node.node_id = poses_cit->first;
-		// pose
-		ros_node.pose = mrpt::ros2bridge::toROS_Pose(poses_cit->second);
-
-		// optional fields for the MR-SLAM case
-		ros_node.str_id.data = poses_cit->second.agent_ID_str;
-		ros_node.node_id_loc = poses_cit->second.nodeID_loc;
-
-		ros_graph.nodes.vec.push_back(ros_node);
-	}
-
-	// fill the constraints -- same as in the conversion from
-	// CNetworkOfPoses2DInf
-	for (const auto& edge : constraints)
-	{
-		mrpt_msgs::msg::GraphConstraint ros_constr;
-
-		// constraint ends
-		ros_constr.node_id_from = edge.first.first;
-		ros_constr.node_id_to = edge.first.second;
-
-		// constraint mean and covariance
-		if (mrpt_graph.edges_store_inverse_poses)
-		{
-			CPosePDFGaussianInf constr_inv;
-			edge.second.inverse(constr_inv);
-			ros_constr.constraint = mrpt::ros2bridge::toROS(constr_inv);
-		}
-		else
-		{
-			ros_constr.constraint = mrpt::ros2bridge::toROS(edge.second);
-		}
-
-		ros_graph.constraints.push_back(ros_constr);
-	}
-
-	MRPT_END
-}
-
-void mrpt_msgs_bridge::toROS(
-	[[maybe_unused]] const mrpt::graphs::CNetworkOfPoses3DInf_NA& mrpt_graph,
-	[[maybe_unused]] mrpt_msgs::msg::NetworkOfPoses& ros_graph)
-{
-	THROW_EXCEPTION("Conversion not implemented yet");
-}
-
 ///////////////////////////////////////////////////////////////////////////////////////////
 // ROS2 => MRPT
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -229,61 +149,9 @@ void mrpt_msgs_bridge::fromROS(
 	// conversion.
 }
 
-void mrpt_msgs_bridge::fromROS(
-	const mrpt_msgs::msg::NetworkOfPoses& ros_graph,
-	mrpt::graphs::CNetworkOfPoses2DInf_NA& mrpt_graph)
-{
-	MRPT_START
-	using namespace mrpt::poses;
-	using namespace mrpt_msgs::msg;
-	using namespace std;
-
-	using nodes_cit_t = NetworkOfPoses::_nodes_type::_vec_type::const_iterator;
-	using constraints_cit_t = NetworkOfPoses::_constraints_type::const_iterator;
-
-	using mrpt_graph_pose_t = mrpt::graphs::CNetworkOfPoses2DInf_NA::global_pose_t;
-
-	// fill root node
-	mrpt_graph.root = ros_graph.root;
-
-	// fill nodeIDs, positions
-	for (nodes_cit_t nodes_cit = ros_graph.nodes.vec.begin();
-		 nodes_cit != ros_graph.nodes.vec.end(); ++nodes_cit)
-	{
-		// set the nodeID/pose
-		mrpt_graph_pose_t mrpt_node = mrpt::ros2bridge::fromROS(nodes_cit->pose);
-
-		// set the MR-SLAM fields
-		mrpt_node.agent_ID_str = nodes_cit->str_id.data;
-		mrpt_node.nodeID_loc = nodes_cit->node_id_loc;
-
-		mrpt_graph.nodes.insert(make_pair(static_cast<TNodeID>(nodes_cit->node_id), mrpt_node));
-	}
-
-	// fill the constraints
-	for (constraints_cit_t constr_cit = ros_graph.constraints.begin();
-		 constr_cit != ros_graph.constraints.end(); ++constr_cit)
-	{
-		// constraint ends
-		auto constr_ends(make_pair(
-			static_cast<TNodeID>(constr_cit->node_id_from),
-			static_cast<TNodeID>(constr_cit->node_id_to)));
-
-		// constraint value
-		const auto mrpt_constr =
-			mrpt::poses::CPosePDFGaussianInf(mrpt::ros2bridge::fromROS(constr_cit->constraint));
-
-		mrpt_graph.edges.insert(make_pair(constr_ends, mrpt_constr));
-	}
-
-	mrpt_graph.edges_store_inverse_poses = false;
-
-	MRPT_END
-}
-
 void convert(
 	[[maybe_unused]] mrpt_msgs::msg::NetworkOfPoses& ros_graph,
-	[[maybe_unused]] const mrpt::graphs::CNetworkOfPoses3DInf_NA& mrpt_graph)
+	[[maybe_unused]] const mrpt::graphs::CNetworkOfPoses3DInf& mrpt_graph)
 {
 	THROW_EXCEPTION("Conversion not implemented yet");
 }

--- a/mrpt_pf_localization/CMakeLists.txt
+++ b/mrpt_pf_localization/CMakeLists.txt
@@ -19,11 +19,13 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(mola_relocalization) # OPTIONAL
 
-find_package(mrpt-ros2bridge REQUIRED)
-find_package(mrpt-gui REQUIRED)
-find_package(mrpt-slam REQUIRED)
+find_package(mrpt_libros_bridge REQUIRED)
+# Ensure workspace mrpt_libros_bridge headers take priority over system ones:
+include_directories(BEFORE ${mrpt_libros_bridge_INCLUDE_DIRS})
+find_package(mrpt_gui REQUIRED)
+find_package(mrpt_slam REQUIRED)
 
-message(STATUS "MRPT_VERSION: ${mrpt-slam_VERSION}")
+message(STATUS "MRPT_VERSION: ${mrpt_slam_VERSION}")
 
 if (CMAKE_COMPILER_IS_GNUCXX)
 	# High level of warnings.
@@ -56,9 +58,9 @@ target_include_directories(${PROJECT_NAME}_core
 )
 
 target_link_libraries(${PROJECT_NAME}_core
-  mrpt::gui
-  mrpt::slam
-  mrpt::ros2bridge
+  mrpt::mrpt_gui
+  mrpt::mrpt_slam
+  mrpt_libros_bridge::mrpt_libros_bridge
   mola::mp2p_icp_map
   mola::mp2p_icp_filters
 )
@@ -78,9 +80,9 @@ add_executable(${PROJECT_NAME}_node
 
 target_link_libraries(${PROJECT_NAME}_node PRIVATE
   ${PROJECT_NAME}_core
-  mrpt::gui
-  mrpt::slam
-  mrpt::ros2bridge
+  mrpt::mrpt_gui
+  mrpt::mrpt_slam
+  mrpt_libros_bridge::mrpt_libros_bridge
   rclcpp::rclcpp
   ${rclcpp_components_TARGETS}
   tf2::tf2
@@ -109,9 +111,9 @@ add_library(${PROJECT_NAME}_component SHARED
 
 target_link_libraries(${PROJECT_NAME}_component PRIVATE
   ${PROJECT_NAME}_core
-  mrpt::gui
-  mrpt::slam
-  mrpt::ros2bridge
+  mrpt::mrpt_gui
+  mrpt::mrpt_slam
+  mrpt_libros_bridge::mrpt_libros_bridge
   rclcpp::rclcpp
   ${rclcpp_components_TARGETS}
   tf2::tf2

--- a/mrpt_pf_localization/CMakeLists.txt
+++ b/mrpt_pf_localization/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(mrpt_libros_bridge REQUIRED)
 include_directories(BEFORE ${mrpt_libros_bridge_INCLUDE_DIRS})
 find_package(mrpt_gui REQUIRED)
 find_package(mrpt_slam REQUIRED)
+find_package(mrpt_viz REQUIRED)
 
 message(STATUS "MRPT_VERSION: ${mrpt_slam_VERSION}")
 
@@ -59,6 +60,7 @@ target_include_directories(${PROJECT_NAME}_core
 
 target_link_libraries(${PROJECT_NAME}_core
   mrpt::mrpt_gui
+  mrpt::mrpt_viz
   mrpt::mrpt_slam
   mrpt_libros_bridge::mrpt_libros_bridge
   mola::mp2p_icp_map
@@ -81,6 +83,7 @@ add_executable(${PROJECT_NAME}_node
 target_link_libraries(${PROJECT_NAME}_node PRIVATE
   ${PROJECT_NAME}_core
   mrpt::mrpt_gui
+  mrpt::mrpt_viz
   mrpt::mrpt_slam
   mrpt_libros_bridge::mrpt_libros_bridge
   rclcpp::rclcpp
@@ -112,6 +115,7 @@ add_library(${PROJECT_NAME}_component SHARED
 target_link_libraries(${PROJECT_NAME}_component PRIVATE
   ${PROJECT_NAME}_core
   mrpt::mrpt_gui
+  mrpt::mrpt_viz
   mrpt::mrpt_slam
   mrpt_libros_bridge::mrpt_libros_bridge
   rclcpp::rclcpp

--- a/mrpt_pf_localization/package.xml
+++ b/mrpt_pf_localization/package.xml
@@ -25,9 +25,9 @@
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <depend>mola_relocalization</depend>
   <depend>mp2p_icp</depend>
-  <depend>mrpt_libgui</depend>
+  <depend>mrpt_gui</depend>
   <depend>mrpt_libros_bridge</depend>
-  <depend>mrpt_libslam</depend>
+  <depend>mrpt_slam</depend>
   <depend>mrpt_msgs</depend>
   <depend>mrpt_msgs_bridge</depend>
   <depend>nav_msgs</depend>

--- a/mrpt_pf_localization/params/map-occgrid2d.ini
+++ b/mrpt_pf_localization/params/map-occgrid2d.ini
@@ -11,10 +11,7 @@
 [MetricMap]
 # Creation of maps:
 occupancyGrid_count=1
-gasGrid_count=0
-landmarksMap_count=0
 pointsMap_count=0
-beaconMap_count=0
 
 # Selection of map for likelihood: (fuseAll=-1,occGrid=0, points=1,landmarks=2,gasGrid=3)
 likelihoodMapSelection=-1

--- a/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
@@ -1064,7 +1064,7 @@ void PFLocalizationCore::init_from_yaml(
 	// Load all required and optional params:
 	params_.load_from(pf_params);
 
-	if (pf_params.asMap().count("log_level_core"))
+	if (pf_params.has("log_level_core"))
 	{
 		const auto coreLogLevel = mrpt::typemeta::str2enum<mrpt::system::VerbosityLevel>(
 			pf_params["log_level_core"].as<std::string>());

--- a/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
@@ -16,9 +16,10 @@
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/obs/CActionCollection.h>
 #include <mrpt/obs/CObservationPointCloud.h>
-#include <mrpt/opengl/CEllipsoid2D.h>
-#include <mrpt/opengl/CEllipsoid3D.h>
-#include <mrpt/opengl/CPointCloud.h>
+#include <mrpt/viz/CEllipsoid2D.h>
+#include <mrpt/viz/CEllipsoid3D.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/opengl_fonts.h>
 #include <mrpt/random/RandomGenerators.h>
 #include <mrpt/ros2bridge/map.h>
 #include <mrpt/system/filesystem.h>
@@ -1124,7 +1125,7 @@ void PFLocalizationCore::init_gui()
 
 void PFLocalizationCore::update_gui(const mrpt::obs::CSensoryFrame& sf)
 {
-	using namespace mrpt::opengl;
+	using namespace mrpt::viz;
 
 	auto tle = mrpt::system::CTimeLoggerEntry(profiler_, "show3DDebug");
 
@@ -1160,13 +1161,13 @@ void PFLocalizationCore::update_gui(const mrpt::obs::CSensoryFrame& sf)
 	}
 	const auto& meanPose = estimatedPose.mean;
 
-	mrpt::opengl::Scene::Ptr scene;
+	mrpt::viz::Scene::Ptr scene;
 	{
 		mrpt::gui::CDisplayWindow3DLocker winLock(*win3D_, scene);
 
 		win3D_->setCameraPointingToPoint(estimatedPose.mean.x(), estimatedPose.mean.y(), 0);
 
-		mrpt::opengl::TFontParams fp;
+		mrpt::viz::TFontParams fp;
 		fp.color = mrpt::img::TColorf(.8f, .8f, .8f);
 		fp.vfont_name = "mono";
 		fp.vfont_scale = 15;

--- a/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
@@ -16,17 +16,17 @@
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/obs/CActionCollection.h>
 #include <mrpt/obs/CObservationPointCloud.h>
-#include <mrpt/viz/CVisualObject.h>
-#include <mrpt/viz/CEllipsoid2D.h>
-#include <mrpt/viz/CEllipsoid3D.h>
-#include <mrpt/viz/CPointCloud.h>
-#include <mrpt/viz/opengl_fonts.h>
 #include <mrpt/random/RandomGenerators.h>
 #include <mrpt/ros2bridge/map.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/hyperlink.h>
 #include <mrpt/topography/conversions.h>  // geodeticToENU_WGS84
 #include <mrpt/topography/data_types.h>	 // TGeodeticCoords
+#include <mrpt/viz/CEllipsoid2D.h>
+#include <mrpt/viz/CEllipsoid3D.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/CVisualObject.h>
+#include <mrpt/viz/opengl_fonts.h>
 #include <mrpt_pf_localization/mrpt_pf_localization_core.h>
 
 #ifdef HAVE_MOLA_RELOCALIZATION

--- a/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization/mrpt_pf_localization_core.cpp
@@ -16,6 +16,7 @@
 #include <mrpt/maps/CSimplePointsMap.h>
 #include <mrpt/obs/CActionCollection.h>
 #include <mrpt/obs/CObservationPointCloud.h>
+#include <mrpt/viz/CVisualObject.h>
 #include <mrpt/viz/CEllipsoid2D.h>
 #include <mrpt/viz/CEllipsoid3D.h>
 #include <mrpt/viz/CPointCloud.h>
@@ -151,8 +152,8 @@ void PFLocalizationCore::Parameters::load_from(const mrpt::containers::yaml& par
 		ASSERT_(params["initial_pose"]["std_x"].isScalar());
 		ASSERT_(params["initial_pose"]["std_y"].isScalar());
 
-		const auto& ipP = params["initial_pose"];
-		const auto& m = ipP["mean"];
+		const mrpt::containers::yaml ipP = params["initial_pose"];
+		const mrpt::containers::yaml m = ipP["mean"];
 		auto& ip = initial_pose;
 		ip.emplace();
 		ip->mean.x(m["x"].as<double>());
@@ -180,7 +181,7 @@ void PFLocalizationCore::Parameters::load_from(const mrpt::containers::yaml& par
 
 	// pf_options:
 	ASSERT_(params.has("pf_options"));
-	auto& pfo = params["pf_options"];
+	mrpt::containers::yaml pfo = params["pf_options"];
 	getOptParam(pfo, pf_options.BETA, "BETA");
 
 	{
@@ -210,7 +211,7 @@ void PFLocalizationCore::Parameters::load_from(const mrpt::containers::yaml& par
 
 	// kld_options:
 	ASSERT_(params.has("kld_options"));
-	auto& kldo = params["kld_options"];
+	mrpt::containers::yaml kldo = params["kld_options"];
 	getOptParam(kldo, kld_options.KLD_binSize_XY, "KLD_binSize_XY");
 	getOptParam(kldo, kld_options.KLD_binSize_PHI, "KLD_binSize_PHI");
 	getOptParam(kldo, kld_options.KLD_delta, "KLD_delta");
@@ -1198,7 +1199,7 @@ void PFLocalizationCore::update_gui(const mrpt::obs::CSensoryFrame& sf)
 
 		// The particles:
 		{
-			CRenderizable::Ptr parts = scene->getByName("particles");
+			mrpt::viz::CVisualObject::Ptr parts = scene->getByName("particles");
 			if (parts) scene->removeObject(parts);
 
 			CSetOfObjects::Ptr p = state_.pdf2d ? state_.pdf2d->getAs3DObject<CSetOfObjects::Ptr>()
@@ -1210,7 +1211,7 @@ void PFLocalizationCore::update_gui(const mrpt::obs::CSensoryFrame& sf)
 		// The particles' covariance as an ellipsoid:
 		if (state_.pdf2d)
 		{
-			CRenderizable::Ptr ellip = scene->getByName("parts_cov");
+			mrpt::viz::CVisualObject::Ptr ellip = scene->getByName("parts_cov");
 			if (!ellip)
 			{
 				auto o = CEllipsoid2D::Create();
@@ -1229,7 +1230,7 @@ void PFLocalizationCore::update_gui(const mrpt::obs::CSensoryFrame& sf)
 		}
 		else
 		{
-			CRenderizable::Ptr ellip = scene->getByName("parts_cov");
+			mrpt::viz::CVisualObject::Ptr ellip = scene->getByName("parts_cov");
 			if (!ellip)
 			{
 				auto o = CEllipsoid3D::Create();
@@ -1249,7 +1250,7 @@ void PFLocalizationCore::update_gui(const mrpt::obs::CSensoryFrame& sf)
 
 		// The laser scan and other observations:
 		{
-			CRenderizable::Ptr scan_pts = scene->getByName("scan");
+			mrpt::viz::CVisualObject::Ptr scan_pts = scene->getByName("scan");
 			if (!scan_pts)
 			{
 				auto o = CPointCloud::Create();

--- a/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
@@ -209,12 +209,11 @@ void PFLocalizationNode::reload_params_from_ros()
 
 	// Helper lambda: find or create a key in a map_t, returning ref to value node_t
 	auto findOrCreate = [](mrpt::containers::yaml::map_t& m,
-						   const std::string&               key) -> mrpt::containers::yaml::node_t&
+						   const std::string& key) -> mrpt::containers::yaml::node_t&
 	{
 		for (auto& kv2 : m)
 		{
-			if (kv2.first.isScalar() && kv2.first.as<std::string>() == key)
-				return kv2.second;
+			if (kv2.first.isScalar() && kv2.first.as<std::string>() == key) return kv2.second;
 		}
 		m.push_back({mrpt::containers::yaml::node_t(key), mrpt::containers::yaml::node_t{}});
 		return m.back().second;

--- a/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
+++ b/mrpt_pf_localization/src/mrpt_pf_localization_component.cpp
@@ -207,6 +207,19 @@ void PFLocalizationNode::reload_params_from_ros()
 	const auto& paramsIf = this->get_node_parameters_interface();
 	const auto& allParams = paramsIf->get_parameter_overrides();
 
+	// Helper lambda: find or create a key in a map_t, returning ref to value node_t
+	auto findOrCreate = [](mrpt::containers::yaml::map_t& m,
+						   const std::string&               key) -> mrpt::containers::yaml::node_t&
+	{
+		for (auto& kv2 : m)
+		{
+			if (kv2.first.isScalar() && kv2.first.as<std::string>() == key)
+				return kv2.second;
+		}
+		m.push_back({mrpt::containers::yaml::node_t(key), mrpt::containers::yaml::node_t{}});
+		return m.back().second;
+	};
+
 	for (const auto& kv : allParams)
 	{
 		// Get param name:
@@ -214,7 +227,7 @@ void PFLocalizationNode::reload_params_from_ros()
 
 		// ROS2 param names may be nested. Convert that back into YAML nodes:
 		// e.g. "foo.bar" -> ["foo"]["bar"].
-		mrpt::containers::yaml::map_t* targetYamlNode = &paramsBlock.node().asMap();
+		mrpt::containers::yaml::map_t* targetMap = &paramsBlock.node().asMap();
 
 		for (auto pos = name.find("."); pos != std::string::npos; pos = name.find("."))
 		{
@@ -223,32 +236,28 @@ void PFLocalizationNode::reload_params_from_ros()
 			const std::string childKey = name.substr(pos + 1);
 			name = childKey;
 
-			// Use subnode:
-			if (auto it = targetYamlNode->find(parentKey); it == targetYamlNode->end())
-			{  // create new:
-				(*targetYamlNode)[parentKey] = mrpt::containers::yaml::Map();
-				targetYamlNode = &(*targetYamlNode)[parentKey].asMap();
-			}
-			else
-			{  // reuse
-				targetYamlNode = &it->second.asMap();
-			}
+			// Use subnode (create if not exists):
+			auto& subNode = findOrCreate(*targetMap, parentKey);
+			if (!std::holds_alternative<mrpt::containers::yaml::map_t>(subNode.d))
+				subNode.d.emplace<mrpt::containers::yaml::map_t>();
+			targetMap = &std::get<mrpt::containers::yaml::map_t>(subNode.d);
 		}
 
-		// Get param value:
+		// Get param value and set it:
+		auto& valueNode = findOrCreate(*targetMap, name);
 		switch (kv.second.get_type())
 		{
 			case rclcpp::ParameterType::PARAMETER_BOOL:
-				(*targetYamlNode)[name] = kv.second.get<bool>();
+				valueNode = mrpt::containers::yaml::node_t(kv.second.get<bool>());
 				break;
 			case rclcpp::ParameterType::PARAMETER_DOUBLE:
-				(*targetYamlNode)[name] = kv.second.get<double>();
+				valueNode = mrpt::containers::yaml::node_t(kv.second.get<double>());
 				break;
 			case rclcpp::ParameterType::PARAMETER_INTEGER:
-				(*targetYamlNode)[name] = kv.second.get<int>();
+				valueNode = mrpt::containers::yaml::node_t(kv.second.get<int64_t>());
 				break;
 			case rclcpp::ParameterType::PARAMETER_STRING:
-				(*targetYamlNode)[name] = kv.second.get<std::string>();
+				valueNode = mrpt::containers::yaml::node_t(kv.second.get<std::string>());
 				break;
 			default:
 				RCLCPP_WARN(

--- a/mrpt_pointcloud_pipeline/CMakeLists.txt
+++ b/mrpt_pointcloud_pipeline/CMakeLists.txt
@@ -11,10 +11,12 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
 ## System dependencies are found with CMake's conventions
-find_package(mrpt-maps REQUIRED)
-find_package(mrpt-obs REQUIRED)
-find_package(mrpt-gui REQUIRED)
-find_package(mrpt-ros2bridge REQUIRED)
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_obs REQUIRED)
+find_package(mrpt_gui REQUIRED)
+find_package(mrpt_libros_bridge REQUIRED)
+# Ensure workspace mrpt_libros_bridge headers take priority over system ones:
+include_directories(BEFORE ${mrpt_libros_bridge_INCLUDE_DIRS})
 
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 99)
@@ -53,10 +55,10 @@ target_include_directories(${PROJECT_NAME}_node
 
 target_link_libraries(
   ${PROJECT_NAME}_node PRIVATE
-  mrpt::maps
-  mrpt::obs
-  mrpt::gui
-  mrpt::ros2bridge
+  mrpt::mrpt_maps
+  mrpt::mrpt_obs
+  mrpt::mrpt_gui
+  mrpt_libros_bridge::mrpt_libros_bridge
   mola::mp2p_icp_filters
   rclcpp::rclcpp
   ${rclcpp_components_TARGETS}
@@ -82,10 +84,10 @@ target_include_directories(${PROJECT_NAME}_component
 
 target_link_libraries(
   ${PROJECT_NAME}_component PRIVATE
-  mrpt::maps
-  mrpt::obs
-  mrpt::gui
-  mrpt::ros2bridge
+  mrpt::mrpt_maps
+  mrpt::mrpt_obs
+  mrpt::mrpt_gui
+  mrpt_libros_bridge::mrpt_libros_bridge
   mola::mp2p_icp_filters
   rclcpp::rclcpp
   ${rclcpp_components_TARGETS}

--- a/mrpt_pointcloud_pipeline/include/mrpt_pointcloud_pipeline/mrpt_pointcloud_pipeline_node.h
+++ b/mrpt_pointcloud_pipeline/include/mrpt_pointcloud_pipeline/mrpt_pointcloud_pipeline_node.h
@@ -18,16 +18,16 @@
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CSensoryFrame.h>
-#include <mrpt/viz/CGridPlaneXY.h>
-#include <mrpt/viz/Scene.h>
-#include <mrpt/viz/CPointCloud.h>
-#include <mrpt/viz/stock_objects.h>
 #include <mrpt/ros2bridge/laser_scan.h>
 #include <mrpt/ros2bridge/point_cloud2.h>
 #include <mrpt/ros2bridge/pose.h>
 #include <mrpt/system/CTimeLogger.h>
 #include <mrpt/system/filesystem.h>
 #include <mrpt/system/string_utils.h>
+#include <mrpt/viz/CGridPlaneXY.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
 
 /* ros2 deps */
 #include <tf2_ros/buffer.h>

--- a/mrpt_pointcloud_pipeline/include/mrpt_pointcloud_pipeline/mrpt_pointcloud_pipeline_node.h
+++ b/mrpt_pointcloud_pipeline/include/mrpt_pointcloud_pipeline/mrpt_pointcloud_pipeline_node.h
@@ -18,10 +18,10 @@
 #include <mrpt/obs/CObservation2DRangeScan.h>
 #include <mrpt/obs/CObservationPointCloud.h>
 #include <mrpt/obs/CSensoryFrame.h>
-#include <mrpt/opengl/CGridPlaneXY.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/CPointCloud.h>
-#include <mrpt/opengl/stock_objects.h>
+#include <mrpt/viz/CGridPlaneXY.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/CPointCloud.h>
+#include <mrpt/viz/stock_objects.h>
 #include <mrpt/ros2bridge/laser_scan.h>
 #include <mrpt/ros2bridge/point_cloud2.h>
 #include <mrpt/ros2bridge/pose.h>

--- a/mrpt_pointcloud_pipeline/package.xml
+++ b/mrpt_pointcloud_pipeline/package.xml
@@ -17,9 +17,9 @@
 
   <!-- DEPS -->
   <depend>mp2p_icp</depend>
-  <depend>mrpt_libgui</depend>
-  <depend>mrpt_libmaps</depend>
-  <depend>mrpt_libobs</depend>
+  <depend>mrpt_gui</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_obs</depend>
   <depend>mrpt_libros_bridge</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>

--- a/mrpt_pointcloud_pipeline/src/mrpt_pointcloud_pipeline_component.cpp
+++ b/mrpt_pointcloud_pipeline/src/mrpt_pointcloud_pipeline_component.cpp
@@ -255,8 +255,7 @@ void LocalObstaclesNode::on_do_publish()
 
 		auto& scene = m_gui_win->get3DSceneAndLock();
 
-		auto gl_obs =
-			mrpt::ptr_cast<mrpt::viz::CSetOfObjects>::from(scene->getByName("obstacles"));
+		auto gl_obs = mrpt::ptr_cast<mrpt::viz::CSetOfObjects>::from(scene->getByName("obstacles"));
 		ASSERT_(!!gl_obs);
 		gl_obs->clear();
 

--- a/mrpt_pointcloud_pipeline/src/mrpt_pointcloud_pipeline_component.cpp
+++ b/mrpt_pointcloud_pipeline/src/mrpt_pointcloud_pipeline_component.cpp
@@ -207,21 +207,21 @@ void LocalObstaclesNode::on_do_publish()
 		if (!m_gui_win)
 		{
 			m_gui_win = mrpt::gui::CDisplayWindow3D::Create("LocalObstaclesNode", 800, 600);
-			mrpt::opengl::COpenGLScene::Ptr& scene = m_gui_win->get3DSceneAndLock();
-			scene->insert(mrpt::opengl::CGridPlaneXY::Create());
-			scene->insert(mrpt::opengl::stock_objects::CornerXYZSimple(1.0, 4.0));
+			mrpt::viz::Scene::Ptr& scene = m_gui_win->get3DSceneAndLock();
+			scene->insert(mrpt::viz::CGridPlaneXY::Create());
+			scene->insert(mrpt::viz::stock_objects::CornerXYZSimple(1.0, 4.0));
 
-			auto gl_obs = mrpt::opengl::CSetOfObjects::Create();
+			auto gl_obs = mrpt::viz::CSetOfObjects::Create();
 			gl_obs->setName("obstacles");
 			scene->insert(gl_obs);
 
-			auto gl_rawpts = mrpt::opengl::CPointCloud::Create();
+			auto gl_rawpts = mrpt::viz::CPointCloud::Create();
 			gl_rawpts->setName("raw_points");
 			gl_rawpts->setPointSize(1.0);
 			gl_rawpts->setColor_u8(TColor(0x00ff00));
 			scene->insert(gl_rawpts);
 
-			auto gl_pts = mrpt::opengl::CPointCloud::Create();
+			auto gl_pts = mrpt::viz::CPointCloud::Create();
 			gl_pts->setName("final_points");
 			gl_pts->setPointSize(4.0);
 			gl_pts->setColor_u8(TColor(0x0000ff));
@@ -256,15 +256,15 @@ void LocalObstaclesNode::on_do_publish()
 		auto& scene = m_gui_win->get3DSceneAndLock();
 
 		auto gl_obs =
-			mrpt::ptr_cast<mrpt::opengl::CSetOfObjects>::from(scene->getByName("obstacles"));
+			mrpt::ptr_cast<mrpt::viz::CSetOfObjects>::from(scene->getByName("obstacles"));
 		ASSERT_(!!gl_obs);
 		gl_obs->clear();
 
 		auto glRawPts =
-			mrpt::ptr_cast<mrpt::opengl::CPointCloud>::from(scene->getByName("raw_points"));
+			mrpt::ptr_cast<mrpt::viz::CPointCloud>::from(scene->getByName("raw_points"));
 
 		auto glFinalPts =
-			mrpt::ptr_cast<mrpt::opengl::CPointCloud>::from(scene->getByName("final_points"));
+			mrpt::ptr_cast<mrpt::viz::CPointCloud>::from(scene->getByName("final_points"));
 
 		scene->getViewport()->addTextMessage(
 			5, 25,
@@ -280,8 +280,8 @@ void LocalObstaclesNode::on_do_publish()
 			mrpt::poses::CPose3D relPose(mrpt::poses::UNINITIALIZED_POSE);
 			relPose.inverseComposeFrom(ipt.robot_pose, curRobotPose);
 
-			mrpt::opengl::CSetOfObjects::Ptr gl_axis =
-				mrpt::opengl::stock_objects::CornerXYZSimple(0.9, 2.0);
+			mrpt::viz::CSetOfObjects::Ptr gl_axis =
+				mrpt::viz::stock_objects::CornerXYZSimple(0.9, 2.0);
 			gl_axis->setPose(relPose);
 			gl_obs->insert(gl_axis);
 		}  // end for

--- a/mrpt_reactivenav2d/CMakeLists.txt
+++ b/mrpt_reactivenav2d/CMakeLists.txt
@@ -16,9 +16,11 @@ find_package(visualization_msgs REQUIRED)
 find_package(mrpt_nav_interfaces REQUIRED)
 
 ## System dependencies are found with CMake's conventions
-find_package(mrpt-ros2bridge REQUIRED)
-find_package(mrpt-nav REQUIRED)
-find_package(mrpt-kinematics REQUIRED)
+find_package(mrpt_libros_bridge REQUIRED)
+# Ensure workspace mrpt_libros_bridge headers take priority over system ones:
+include_directories(BEFORE ${mrpt_libros_bridge_INCLUDE_DIRS})
+find_package(mrpt_nav REQUIRED)
+find_package(mrpt_kinematics REQUIRED)
 
 message(STATUS "MRPT_VERSION: ${MRPT_VERSION}")
 if(NOT CMAKE_C_STANDARD)
@@ -61,9 +63,9 @@ target_include_directories(${PROJECT_NAME}_node
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}_node PRIVATE
-  mrpt::nav
-  mrpt::kinematics
-  mrpt::ros2bridge
+  mrpt::mrpt_nav
+  mrpt::mrpt_kinematics
+  mrpt_libros_bridge::mrpt_libros_bridge
   rclcpp::rclcpp
   ${rclcpp_components_TARGETS}
   ${nav_msgs_TARGETS}

--- a/mrpt_reactivenav2d/include/mrpt_reactivenav2d/mrpt_reactivenav2d_node.hpp
+++ b/mrpt_reactivenav2d/include/mrpt_reactivenav2d/mrpt_reactivenav2d_node.hpp
@@ -148,10 +148,7 @@ class ReactiveNav2DNode : public rclcpp::Node
 		 *	 \param curW Current angular speed, in radians per second.
 		 * \return false on any error.
 		 */
-		bool getCurrentPoseAndSpeeds(
-			mrpt::math::TPose2D& curPose, mrpt::math::TTwist2D& curVel,
-			mrpt::system::TTimeStamp& timestamp, mrpt::math::TPose2D& curOdometry,
-			std::string& frame_id) override;
+		std::optional<CurrentPoseAndSpeeds> getCurrentPoseAndSpeeds() override;
 
 		/** Change the instantaneous speeds of robot.
 		 *   \param v Linear speed, in meters per second.
@@ -160,7 +157,7 @@ class ReactiveNav2DNode : public rclcpp::Node
 		 */
 		bool changeSpeeds(const mrpt::kinematics::CVehicleVelCmd& vel_cmd) override;
 
-		bool stop(bool isEmergency) override;
+		bool stop(mrpt::nav::StopType stopType = mrpt::nav::StopType::Emergency) override;
 
 		/** Start the watchdog timer of the robot platform, if any.
 		 * \param T_ms Period, in ms.

--- a/mrpt_reactivenav2d/package.xml
+++ b/mrpt_reactivenav2d/package.xml
@@ -16,7 +16,7 @@
 
   <!-- DEPS -->
   <depend>geometry_msgs</depend>
-  <depend>mrpt_libnav</depend>
+  <depend>mrpt_nav</depend>
   <depend>mrpt_libros_bridge</depend>
   <depend>mrpt_nav_interfaces</depend>
   <depend>nav_msgs</depend>

--- a/mrpt_reactivenav2d/src/mrpt_reactivenav2d_node.cpp
+++ b/mrpt_reactivenav2d/src/mrpt_reactivenav2d_node.cpp
@@ -796,7 +796,7 @@ void ReactiveNav2DNode::execute_action_wp(
 }
 
 std::optional<ReactiveNav2DNode::MyReactiveInterface::CurrentPoseAndSpeeds>
-ReactiveNav2DNode::MyReactiveInterface::getCurrentPoseAndSpeeds()
+	ReactiveNav2DNode::MyReactiveInterface::getCurrentPoseAndSpeeds()
 {
 	using mrpt::system::CTimeLoggerEntry;
 

--- a/mrpt_reactivenav2d/src/mrpt_reactivenav2d_node.cpp
+++ b/mrpt_reactivenav2d/src/mrpt_reactivenav2d_node.cpp
@@ -654,7 +654,7 @@ void ReactiveNav2DNode::execute_action_goal(const std::shared_ptr<HandleNavigate
 		const auto curNavEnded = currentNavEndedSuccessfully_;
 		currentNavEndedSuccessfullyMtx_.unlock();
 
-		if (navState == mrpt::nav::CAbstractNavigator::NAV_ERROR ||
+		if (navState == mrpt::nav::CAbstractNavigator::TState::NAV_ERROR ||
 			(curNavEnded.has_value() && *curNavEnded == false))
 		{
 			result->state.navigation_status =
@@ -762,7 +762,7 @@ void ReactiveNav2DNode::execute_action_wp(
 		const auto curNavEnded = currentNavEndedSuccessfully_;
 		currentNavEndedSuccessfullyMtx_.unlock();
 
-		if (navState == mrpt::nav::CAbstractNavigator::NAV_ERROR ||
+		if (navState == mrpt::nav::CAbstractNavigator::TState::NAV_ERROR ||
 			(curNavEnded.has_value() && *curNavEnded == false))
 		{
 			result->state.navigation_status =
@@ -795,16 +795,13 @@ void ReactiveNav2DNode::execute_action_wp(
 	}
 }
 
-bool ReactiveNav2DNode::MyReactiveInterface::getCurrentPoseAndSpeeds(
-	mrpt::math::TPose2D& curPose, mrpt::math::TTwist2D& curVel, mrpt::system::TTimeStamp& timestamp,
-	mrpt::math::TPose2D& curOdometry, std::string& frame_id)
+std::optional<ReactiveNav2DNode::MyReactiveInterface::CurrentPoseAndSpeeds>
+ReactiveNav2DNode::MyReactiveInterface::getCurrentPoseAndSpeeds()
 {
 	using mrpt::system::CTimeLoggerEntry;
-	double curV, curW;
 
 	CTimeLoggerEntry tle(parent_.profiler_, "getCurrentPoseAndSpeeds");
 
-	// rclcpp::Duration timeout(0.1);
 	rclcpp::Duration timeout(std::chrono::milliseconds(100));
 
 	geometry_msgs::msg::TransformStamped tfGeom;
@@ -819,7 +816,7 @@ bool ReactiveNav2DNode::MyReactiveInterface::getCurrentPoseAndSpeeds(
 	catch (const tf2::TransformException& ex)
 	{
 		RCLCPP_ERROR(parent_.get_logger(), "%s", ex.what());
-		return false;
+		return std::nullopt;
 	}
 
 	tf2::Transform txRobotPose;
@@ -827,22 +824,20 @@ bool ReactiveNav2DNode::MyReactiveInterface::getCurrentPoseAndSpeeds(
 
 	const mrpt::poses::CPose3D curRobotPose = mrpt::ros2bridge::fromROS(txRobotPose);
 
-	timestamp = mrpt::ros2bridge::fromROS(tfGeom.header.stamp);
+	CurrentPoseAndSpeeds ret;
+	ret.timestamp = mrpt::ros2bridge::fromROS(tfGeom.header.stamp);
 
 	// Explicit 3d->2d to confirm we know we're losing information
-	curPose = mrpt::poses::CPose2D(curRobotPose).asTPose();
-	curOdometry = curPose;
+	ret.pose = mrpt::poses::CPose2D(curRobotPose).asTPose();
+	ret.odometry = ret.pose;
 
-	curV = curW = 0;
 	MRPT_TODO("Retrieve current speeds from /odom topic?");
 	RCLCPP_DEBUG(
 		parent_.get_logger(), "[getCurrentPoseAndSpeeds] Latest pose: %s",
-		curPose.asString().c_str());
+		ret.pose.asString().c_str());
 
-	// From local to global:
-	curVel = mrpt::math::TTwist2D(curV, .0, curW).rotated(curPose.phi);
-
-	return true;
+	// velGlobal stays zero (not implemented)
+	return ret;
 }
 
 bool ReactiveNav2DNode::MyReactiveInterface::changeSpeeds(
@@ -864,7 +859,7 @@ bool ReactiveNav2DNode::MyReactiveInterface::changeSpeeds(
 	return true;
 }
 
-bool ReactiveNav2DNode::MyReactiveInterface::stop(bool isEmergency)
+bool ReactiveNav2DNode::MyReactiveInterface::stop(mrpt::nav::StopType /*stopType*/)
 {
 	mrpt::kinematics::CVehicleVelCmd_DiffDriven vel_cmd;
 	vel_cmd.lin_vel = 0;

--- a/mrpt_tps_astar_planner/CMakeLists.txt
+++ b/mrpt_tps_astar_planner/CMakeLists.txt
@@ -17,14 +17,16 @@ find_package(visualization_msgs REQUIRED)
 
 
 ## System dependencies are found with CMake's conventions
-find_package(mrpt-ros2bridge REQUIRED)
-find_package(mrpt-nav REQUIRED)
-find_package(mrpt-kinematics REQUIRED)
-find_package(mrpt-math REQUIRED)
-find_package(mrpt-system REQUIRED)
-find_package(mrpt-containers REQUIRED)
-find_package(mrpt-maps REQUIRED)
-find_package(mrpt-gui REQUIRED)
+find_package(mrpt_libros_bridge REQUIRED)
+# Ensure workspace mrpt_libros_bridge headers take priority over system ones:
+include_directories(BEFORE ${mrpt_libros_bridge_INCLUDE_DIRS})
+find_package(mrpt_nav REQUIRED)
+find_package(mrpt_kinematics REQUIRED)
+find_package(mrpt_math REQUIRED)
+find_package(mrpt_system REQUIRED)
+find_package(mrpt_containers REQUIRED)
+find_package(mrpt_maps REQUIRED)
+find_package(mrpt_gui REQUIRED)
 find_package(mrpt-opengl REQUIRED)
 
 find_package(mrpt_path_planning REQUIRED)
@@ -70,9 +72,9 @@ add_executable(${PROJECT_NAME}_node
 
 # Specify libraries to link a library or executable target against
 target_link_libraries(${PROJECT_NAME}_node PRIVATE
-  mrpt::nav
-  mrpt::kinematics
-  mrpt::ros2bridge
+  mrpt::mrpt_nav
+  mrpt::mrpt_kinematics
+  mrpt_libros_bridge::mrpt_libros_bridge
   mrpt_path_planning::mrpt_path_planning
   rclcpp::rclcpp
   ${rclcpp_components_TARGETS}

--- a/mrpt_tps_astar_planner/CMakeLists.txt
+++ b/mrpt_tps_astar_planner/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(mrpt_system REQUIRED)
 find_package(mrpt_containers REQUIRED)
 find_package(mrpt_maps REQUIRED)
 find_package(mrpt_gui REQUIRED)
-find_package(mrpt-opengl REQUIRED)
+find_package(mrpt_opengl REQUIRED)
 
 find_package(mrpt_path_planning REQUIRED)
 if (TARGET mrpt_path_planning AND NOT TARGET mrpt_path_planning::mrpt_path_planning)

--- a/mrpt_tps_astar_planner/package.xml
+++ b/mrpt_tps_astar_planner/package.xml
@@ -16,9 +16,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <!-- DEPS -->
-  <depend>mrpt_libgui</depend>
-  <depend>mrpt_libmaps</depend>
-  <depend>mrpt_libnav</depend>
+  <depend>mrpt_gui</depend>
+  <depend>mrpt_maps</depend>
+  <depend>mrpt_nav</depend>
   <depend>mrpt_libros_bridge</depend>
   <depend>mrpt_msgs</depend>
   <depend>mrpt_nav_interfaces</depend>

--- a/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
+++ b/mrpt_tps_astar_planner/src/mrpt_tps_astar_planner_node.cpp
@@ -64,9 +64,9 @@
 #include <thread>
 
 // for debugging
-#include <mrpt/opengl/CGridPlaneXY.h>
-#include <mrpt/opengl/COpenGLScene.h>
-#include <mrpt/opengl/stock_objects.h>
+#include <mrpt/viz/CGridPlaneXY.h>
+#include <mrpt/viz/Scene.h>
+#include <mrpt/viz/stock_objects.h>
 
 // version:
 #include <mrpt/version.h>


### PR DESCRIPTION
Port to MRPT 3.x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Updated MRPT integrations across mapping, localization, navigation, point-cloud, and planning components for current package and visualization interfaces.
  * Workspace ROS bridge headers now take priority where applicable.

* **Behavior Changes**
  * Removed ROS conversions for MR-SLAM-specific network-of-poses variants.
  * Network-of-poses conversions now use standard graph data without MR-SLAM identifiers.
  * Reactive navigation pose/status retrieval and stop commands now use updated result and stop-type handling.

* **Maintenance**
  * Updated package dependencies and configuration for the current MRPT library structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->